### PR TITLE
fix: use configured simulator account instead of hardcoded public key

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,4 @@ HORIZON_URL=https://horizon-testnet.stellar.org
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 CONTRACT_ID=
+SIMULATOR_ACCOUNT=

--- a/backend/src/routes/splits.ts
+++ b/backend/src/routes/splits.ts
@@ -213,8 +213,15 @@ async function fetchProjectById(projectId: string) {
   const server = new rpc.Server(config.sorobanRpcUrl, { allowHttp: true });
   const contract = new Contract(config.contractId);
 
+  let simulatorAccount: Account;
+  try {
+    simulatorAccount = await server.getAccount(config.simulatorAccount);
+  } catch {
+    throw new RequestValidationError("simulator account not found on selected network");
+  }
+
   // 1. Fetch project details
-  const projectTx = new TransactionBuilder(new Account("GBRPYHIL2C4YVYC3Q4W4A6FTZVJ35UEDPKBQ6F4NNDM44YXV2RDJX2KE", "0"), {
+  const projectTx = new TransactionBuilder(simulatorAccount, {
     fee: BASE_FEE,
     networkPassphrase: config.networkPassphrase
   })
@@ -233,7 +240,7 @@ async function fetchProjectById(projectId: string) {
   }
 
   // 2. Fetch project balance
-  const balanceTx = new TransactionBuilder(new Account("GBRPYHIL2C4YVYC3Q4W4A6FTZVJ35UEDPKBQ6F4NNDM44YXV2RDJX2KE", "0"), {
+  const balanceTx = new TransactionBuilder(simulatorAccount, {
     fee: BASE_FEE,
     networkPassphrase: config.networkPassphrase
   })

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -3,6 +3,7 @@ export interface StellarConfig {
   sorobanRpcUrl: string;
   networkPassphrase: string;
   contractId: string;
+  simulatorAccount: string;
 }
 
 export class RequestValidationError extends Error {
@@ -17,10 +18,11 @@ export function loadStellarConfig(): StellarConfig {
     HORIZON_URL,
     SOROBAN_RPC_URL,
     SOROBAN_NETWORK_PASSPHRASE,
-    CONTRACT_ID
+    CONTRACT_ID,
+    SIMULATOR_ACCOUNT
   } = process.env;
 
-  if (!HORIZON_URL || !SOROBAN_RPC_URL || !SOROBAN_NETWORK_PASSPHRASE || !CONTRACT_ID) {
+  if (!HORIZON_URL || !SOROBAN_RPC_URL || !SOROBAN_NETWORK_PASSPHRASE || !CONTRACT_ID || !SIMULATOR_ACCOUNT) {
     throw new Error("Missing Stellar configuration env vars.");
   }
 
@@ -28,6 +30,7 @@ export function loadStellarConfig(): StellarConfig {
     horizonUrl: HORIZON_URL,
     sorobanRpcUrl: SOROBAN_RPC_URL,
     networkPassphrase: SOROBAN_NETWORK_PASSPHRASE,
-    contractId: CONTRACT_ID
+    contractId: CONTRACT_ID,
+    simulatorAccount: SIMULATOR_ACCOUNT
   };
 }


### PR DESCRIPTION
## Summary
- Removes hardcoded Stellar public key from `fetchProjectById` simulation calls
- Adds `SIMULATOR_ACCOUNT` environment variable for configuring the simulation source account
- Works across networks since the account is configurable

Closes #62