### PR TITLE
feat: Implement distribute flow UI, list_projects pagination, and withdraw_unallocated

### DIFF
--- a/frontend/src/components/split-app.test.tsx
+++ b/frontend/src/components/split-app.test.tsx
@@ -166,3 +166,85 @@ describe("SplitApp lock project flow", () => {
     });
   });
 });
+
+describe("SplitApp distribute flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: true,
+      address: "GOWNER123",
+      network: "testnet"
+    });
+    mocks.mockGetProjectHistory.mockResolvedValue([]);
+    mocks.mockGetSplit.mockResolvedValue({ ...baseProject, balance: "5000" });
+    mocks.mockSignWithFreighter.mockResolvedValue("SIGNED_XDR");
+    mocks.mockBuildDistributeXdr.mockResolvedValue({
+      xdr: "DISTRIBUTE_XDR",
+      metadata: { networkPassphrase: "TESTNET", contractId: "CID" }
+    });
+    mocks.mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "DIST_TX_HASH" });
+  });
+
+  it("shows distribute button when project has balance and wallet connected", async () => {
+    await loadProject();
+    expect(screen.getByRole("button", { name: "Trigger Distribution" })).toBeInTheDocument();
+  });
+
+  it("opens distribution modal with Final Confirmation heading", async () => {
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+
+    expect(screen.getByRole("heading", { name: "Final Confirmation" })).toBeInTheDocument();
+    expect(screen.getByText(/Splitting/)).toBeInTheDocument();
+    expect(screen.getByText("5,000 stroops")).toBeInTheDocument();
+  });
+
+  it("shows collaborator payment preview in modal", async () => {
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+
+    const modal = screen.getByRole("heading", { name: "Final Confirmation" }).parentElement;
+    expect(within(modal!).getByText("60.00% Share")).toBeInTheDocument();
+    expect(within(modal!).getByText("40.00% Share")).toBeInTheDocument();
+  });
+
+  it("cancels distribution when cancel button clicked", async () => {
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Final Confirmation" })).not.toBeInTheDocument();
+    });
+    expect(mocks.mockBuildDistributeXdr).not.toHaveBeenCalled();
+  });
+
+  it("executes distribution and calls buildDistributeXdr", async () => {
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+    await user.click(screen.getByRole("button", { name: "Execute Payout" }));
+
+    await waitFor(() => {
+      expect(mocks.mockBuildDistributeXdr).toHaveBeenCalledWith("project_1", "GOWNER123");
+    });
+  });
+
+  it("disables distribute button when wallet not connected", async () => {
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: false,
+      address: null,
+      network: null
+    });
+
+    await loadProject();
+    expect(screen.getByRole("button", { name: "Trigger Distribution" })).toBeDisabled();
+  });
+
+  it("disables distribute button when balance is zero", async () => {
+    mocks.mockGetSplit.mockResolvedValue({ ...baseProject, balance: "0" });
+
+    await loadProject();
+    expect(screen.getByRole("button", { name: "Trigger Distribution" })).toBeDisabled();
+    expect(screen.getByText("No funds available to distribute")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/split-app.tsx
+++ b/frontend/src/components/split-app.tsx
@@ -1260,6 +1260,37 @@ export function SplitApp() {
                         No funds available to distribute
                       </p>
                     )}
+
+                    {txHash && (
+                      <div className="mt-6 rounded-2xl border border-greenBright/20 bg-greenBright/5 p-5 animate-in fade-in slide-in-from-bottom-4">
+                        <div className="flex items-start gap-4">
+                          <div className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-greenBright/10">
+                            <svg className="h-5 w-5 text-greenBright" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                            </svg>
+                          </div>
+                          <div className="space-y-1">
+                            <h4 className="text-xs font-bold text-greenBright uppercase tracking-widest">
+                              Distribution Successful
+                            </h4>
+                            <p className="text-[10px] text-muted">
+                              Round #{fetchedProject.distributionRound + 1} completed
+                            </p>
+                            <p className="font-mono text-[10px] text-muted break-all opacity-80">
+                              Tx: {txHash}
+                            </p>
+                            <a
+                              href={`https://stellar.expert/explorer/testnet/tx/${txHash}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="inline-block pt-1 text-[10px] font-bold text-greenBright underline underline-offset-4 hover:text-white"
+                            >
+                              View on Explorer →
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,15 +28,6 @@ interface BuildSplitResponse {
     contractId: string;
   };
 }
-export interface ProjectHistoryItem {
-  id: string;
-  type: "round" | "payment";
-  txHash: string;
-  ledgerCloseTime: string;
-  round?: number;
-  amount: string;
-  recipient?: string;
-}
 function toErrorMessage(status: number, payload: unknown, fallback: string) {
   if (payload && typeof payload === "object" && "message" in payload) {
     const message = (payload as { message?: unknown }).message;


### PR DESCRIPTION
## Summary
This PR implements the following features for the SplitNaira project:

### Issue #73 - Frontend: Add distribute flow UI
- Added transaction hash display in the manage tab after successful distribution
- Added round increment display showing which distribution round was completed
- Added comprehensive tests for the distribute flow UI

### Issue #93 - Contracts: Add list_projects pagination API
- Already implemented in the contract with `list_projects(start, limit)` function
- Full test coverage with pagination, bounds, and empty list tests

### Issue #95 - Contracts: Add withdraw_unallocated / admin recovery mechanism
- Already implemented `withdraw_unallocated` function for admin recovery
- Full test coverage for success cases and error cases

## Changes Made
- `frontend/src/components/split-app.tsx`: Added tx hash display section after distribution
- `frontend/src/components/split-app.test.tsx`: Added 7 new tests for distribute flow
- `frontend/src/lib/api.ts`: Fixed duplicate `ProjectHistoryItem` interface

## Testing
- All 39 contract tests pass
- All 16 frontend tests pass

Closes #73
Closes #93
Closes #95