### PR TITLE
feat: add unsigned XDR builder routes for allow_token and disallow_token

### DIFF
--- a/backend/src/routes/splits.test.ts
+++ b/backend/src/routes/splits.test.ts
@@ -217,6 +217,112 @@ describe("splits routes integration", () => {
     expect(getAccountMock).toHaveBeenCalledWith("GTESTSIMULATOR");
   });
 
+  it("builds allow_token transaction", async () => {
+    getAccountMock.mockResolvedValue({ accountId: "GADMIN" });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "XDR_ALLOW_TOKEN",
+      sequence: "100",
+      fee: "100"
+    });
+
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/allow-token")
+      .send({ admin: "GADMIN", token: "GTOKEN" })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      xdr: "XDR_ALLOW_TOKEN",
+      metadata: {
+        contractId: "TESTCONTRACT",
+        networkPassphrase: "Test SDF Network",
+        sourceAccount: "GADMIN",
+        operation: "allow_token"
+      }
+    });
+
+    expect(getAccountMock).toHaveBeenCalledWith("GADMIN");
+  });
+
+  it("builds disallow_token transaction", async () => {
+    getAccountMock.mockResolvedValue({ accountId: "GADMIN" });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "XDR_DISALLOW_TOKEN",
+      sequence: "101",
+      fee: "100"
+    });
+
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/disallow-token")
+      .send({ admin: "GADMIN", token: "GTOKEN" })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      xdr: "XDR_DISALLOW_TOKEN",
+      metadata: {
+        contractId: "TESTCONTRACT",
+        networkPassphrase: "Test SDF Network",
+        sourceAccount: "GADMIN",
+        operation: "disallow_token"
+      }
+    });
+
+    expect(getAccountMock).toHaveBeenCalledWith("GADMIN");
+  });
+
+  it("returns 400 for allow_token with missing fields", async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/allow-token")
+      .send({ admin: "GADMIN" }) // missing token
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+  });
+
+  it("returns 400 for disallow_token with missing fields", async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/disallow-token")
+      .send({ token: "GTOKEN" }) // missing admin
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+  });
+
+  it("returns 400 for allow_token when admin account not found", async () => {
+    getAccountMock.mockRejectedValue(new Error("not found"));
+
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/allow-token")
+      .send({ admin: "GADMIN", token: "GTOKEN" })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(response.body.message).toMatch(/admin account not found/);
+  });
+
+  it("returns 400 for disallow_token when admin account not found", async () => {
+    getAccountMock.mockRejectedValue(new Error("not found"));
+
+    const app = createApp();
+
+    const response = await request(app)
+      .post("/splits/admin/disallow-token")
+      .send({ admin: "GADMIN", token: "GTOKEN" })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(response.body.message).toMatch(/admin account not found/);
+  });
+
   it("retrieves history filtered and sorted", async () => {
     getAccountMock.mockResolvedValue({ accountId: "GSIM" });
 

--- a/backend/src/routes/splits.ts
+++ b/backend/src/routes/splits.ts
@@ -731,6 +731,156 @@ splitsRouter.post("/:projectId/distribute", async (req: Request, res: Response, 
   }
 });
 
+const adminTokenSchema = z.object({
+  admin: stellarAddressSchema.describe("admin"),
+  token: stellarAddressSchema.describe("token")
+});
+
+interface AdminTokenRequest {
+  admin: string;
+  token: string;
+}
+
+async function buildAllowTokenUnsignedXdr(input: AdminTokenRequest) {
+  const config = loadStellarConfig();
+  const server = getStellarRpcServer();
+
+  let sourceAccount;
+  try {
+    sourceAccount = await server.getAccount(input.admin);
+  } catch {
+    throw new RequestValidationError("admin account not found on selected network");
+  }
+
+  const adminAddress = Address.fromString(input.admin);
+  const tokenAddress = Address.fromString(input.token);
+
+  const contract = new Contract(config.contractId);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: config.networkPassphrase
+  })
+    .addOperation(
+      contract.call("allow_token", adminAddress.toScVal(), tokenAddress.toScVal())
+    )
+    .setTimeout(300)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  return {
+    xdr: preparedTx.toXDR(),
+    metadata: {
+      contractId: config.contractId,
+      networkPassphrase: config.networkPassphrase,
+      sourceAccount: input.admin,
+      sequenceNumber: preparedTx.sequence,
+      fee: preparedTx.fee,
+      operation: "allow_token"
+    }
+  };
+}
+
+async function buildDisallowTokenUnsignedXdr(input: AdminTokenRequest) {
+  const config = loadStellarConfig();
+  const server = getStellarRpcServer();
+
+  let sourceAccount;
+  try {
+    sourceAccount = await server.getAccount(input.admin);
+  } catch {
+    throw new RequestValidationError("admin account not found on selected network");
+  }
+
+  const adminAddress = Address.fromString(input.admin);
+  const tokenAddress = Address.fromString(input.token);
+
+  const contract = new Contract(config.contractId);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: config.networkPassphrase
+  })
+    .addOperation(
+      contract.call("disallow_token", adminAddress.toScVal(), tokenAddress.toScVal())
+    )
+    .setTimeout(300)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  return {
+    xdr: preparedTx.toXDR(),
+    metadata: {
+      contractId: config.contractId,
+      networkPassphrase: config.networkPassphrase,
+      sourceAccount: input.admin,
+      sequenceNumber: preparedTx.sequence,
+      fee: preparedTx.fee,
+      operation: "disallow_token"
+    }
+  };
+}
+
+splitsRouter.post("/admin/allow-token", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    const parsed = adminTokenSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "validation_error",
+        message: "Invalid request payload.",
+        details: parsed.error.flatten(),
+        requestId
+      });
+    }
+
+    try {
+      const result = await buildAllowTokenUnsignedXdr(parsed.data);
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({
+          error: "validation_error",
+          message: error.message,
+          requestId
+        });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+splitsRouter.post("/admin/disallow-token", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    const parsed = adminTokenSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "validation_error",
+        message: "Invalid request payload.",
+        details: parsed.error.flatten(),
+        requestId
+      });
+    }
+
+    try {
+      const result = await buildDisallowTokenUnsignedXdr(parsed.data);
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({
+          error: "validation_error",
+          message: error.message,
+          requestId
+        });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
 const historyQuerySchema = z.object({
   cursor: z.string().default(""),
   limit: z.coerce.number().int().min(1).max(200).default(100)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -92,7 +92,7 @@
           },
           "operation": {
             "type": "string",
-            "description": "The operation being performed. Possible values: create_project, lock_project, update_collaborators, distribute",
+            "description": "The operation being performed. Possible values: create_project, lock_project, update_collaborators, distribute, allow_token, disallow_token",
             "example": "create_project"
           }
         },
@@ -262,6 +262,15 @@
         "type": "object",
         "properties": {
           "sourceAddress": { "type": "string", "example": "GABCDEF12345..." }
+        },
+        "additionalProperties": false
+      },
+      "AdminTokenRequest": {
+        "type": "object",
+        "required": ["admin", "token"],
+        "properties": {
+          "admin": { "type": "string", "example": "GADMIN12345..." },
+          "token": { "type": "string", "example": "CTOKEN1234..." }
         },
         "additionalProperties": false
       },
@@ -876,6 +885,110 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/HistoryResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/splits/admin/allow-token": {
+      "post": {
+        "tags": ["splits"],
+        "summary": "Build unsigned transaction to add a token to the allowlist",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AdminTokenRequest" },
+              "example": {
+                "admin": "GADMIN12345...",
+                "token": "CTOKEN1234..."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transaction built",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BuildTransactionResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RequestIdError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/splits/admin/disallow-token": {
+      "post": {
+        "tags": ["splits"],
+        "summary": "Build unsigned transaction to remove a token from the allowlist",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AdminTokenRequest" },
+              "example": {
+                "admin": "GADMIN12345...",
+                "token": "CTOKEN1234..."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transaction built",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/BuildTransactionResponse" }
               }
             }
           },


### PR DESCRIPTION
Adds POST /splits/admin/allow-token and POST /splits/admin/disallow-token routes that prepare unsigned XDR for the contract's token allowlist admin functions. Includes request validation, source-account error handling, tests, and OpenAPI docs.

Closes #153