### PR TITLE
#174 Implement owner-gating and lock lifecycle tests,.......

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -817,9 +817,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -834,9 +831,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -851,9 +845,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -868,9 +859,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -885,9 +873,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -902,9 +887,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -919,9 +901,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,9 +915,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -953,9 +929,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +943,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,9 +957,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,9 +971,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,9 +985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/backend/src/routes/splits.test.ts
+++ b/backend/src/routes/splits.test.ts
@@ -268,3 +268,217 @@ describe("splits routes integration", () => {
     expect(getEventsMock).toHaveBeenCalledTimes(2);
   });
 });
+
+// ============================================================
+//  ISSUE #174 — Lock & Update Owner-Gating Integration Tests
+// ============================================================
+
+describe("Issue #174: lock & update permissions and owner gating", () => {
+  const VALID_OWNER = "GOWNER";
+  const VALID_TOKEN = "GTOKEN";
+  const VALID_COLLAB_A = "GCOLLABA";
+  const VALID_COLLAB_B = "GCOLLABB";
+  const VALID_COLLAB_C = "GCOLLABC";
+
+  it("lock route passes owner through as sourceAccount in built XDR", async () => {
+    getAccountMock.mockResolvedValue({ accountId: VALID_OWNER });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "XDR_LOCK",
+      sequence: "1",
+      fee: "100"
+    });
+
+    const app = createApp();
+    const response = await request(app)
+      .post("/splits/proj_a/lock")
+      .send({ owner: VALID_OWNER })
+      .expect(200);
+
+    expect(response.body.metadata.sourceAccount).toBe(VALID_OWNER);
+    expect(response.body.metadata.operation).toBe("lock_project");
+    expect(getAccountMock).toHaveBeenCalledWith(VALID_OWNER);
+  });
+
+  it("lock route rejects missing owner with 400 validation_error", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post("/splits/proj_a/lock")
+      .send({})
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("lock route rejects invalid projectId (non-alphanumeric) with 400", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .post("/splits/bad-id!/lock")
+      .send({ owner: VALID_OWNER })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("lock route surfaces 'owner account not found' as 400 when RPC lookup fails", async () => {
+    getAccountMock.mockRejectedValue(new Error("not_found"));
+
+    const app = createApp();
+    const response = await request(app)
+      .post("/splits/proj_a/lock")
+      .send({ owner: VALID_OWNER })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(response.body.message).toMatch(/owner account not found/);
+  });
+
+  it("update-collaborators route passes owner through as sourceAccount", async () => {
+    getAccountMock.mockResolvedValue({ accountId: VALID_OWNER });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "XDR_UPDATE",
+      sequence: "2",
+      fee: "100"
+    });
+
+    const app = createApp();
+    const response = await request(app)
+      .put("/splits/proj_a/collaborators")
+      .send({
+        owner: VALID_OWNER,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 6000 },
+          { address: VALID_COLLAB_B, alias: "B", basisPoints: 4000 }
+        ]
+      })
+      .expect(200);
+
+    expect(response.body.metadata.sourceAccount).toBe(VALID_OWNER);
+    expect(response.body.metadata.operation).toBe("update_collaborators");
+    expect(getAccountMock).toHaveBeenCalledWith(VALID_OWNER);
+  });
+
+  it("update-collaborators rejects missing owner with 400", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .put("/splits/proj_a/collaborators")
+      .send({
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 5000 },
+          { address: VALID_COLLAB_B, alias: "B", basisPoints: 5000 }
+        ]
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("update-collaborators rejects basisPoints that don't sum to 10000", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .put("/splits/proj_a/collaborators")
+      .send({
+        owner: VALID_OWNER,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 6000 },
+          { address: VALID_COLLAB_B, alias: "B", basisPoints: 3000 }
+        ]
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("update-collaborators rejects duplicate collaborator addresses", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .put("/splits/proj_a/collaborators")
+      .send({
+        owner: VALID_OWNER,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 5000 },
+          { address: VALID_COLLAB_A, alias: "A2", basisPoints: 5000 }
+        ]
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("update-collaborators rejects fewer than 2 collaborators", async () => {
+    const app = createApp();
+    const response = await request(app)
+      .put("/splits/proj_a/collaborators")
+      .send({
+        owner: VALID_OWNER,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 10000 }
+        ]
+      })
+      .expect(400);
+
+    expect(response.body.error).toBe("validation_error");
+    expect(getAccountMock).not.toHaveBeenCalled();
+  });
+
+  it("full lifecycle: same owner can create → update collaborators → lock", async () => {
+    getAccountMock.mockResolvedValue({ accountId: VALID_OWNER });
+    prepareTransactionMock
+      .mockResolvedValueOnce({ toXDR: () => "XDR_CREATE", sequence: "1", fee: "100" })
+      .mockResolvedValueOnce({ toXDR: () => "XDR_UPDATE", sequence: "2", fee: "100" })
+      .mockResolvedValueOnce({ toXDR: () => "XDR_LOCK", sequence: "3", fee: "100" });
+
+    const app = createApp();
+
+    // 1. Create
+    const createRes = await request(app)
+      .post("/splits")
+      .send({
+        owner: VALID_OWNER,
+        projectId: "lifecycle_1",
+        title: "Lifecycle Project",
+        projectType: "music",
+        token: VALID_TOKEN,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 5000 },
+          { address: VALID_COLLAB_B, alias: "B", basisPoints: 5000 }
+        ]
+      })
+      .expect(200);
+    expect(createRes.body.metadata.operation).toBe("create_project");
+    expect(createRes.body.metadata.sourceAccount).toBe(VALID_OWNER);
+
+    // 2. Update collaborators (still pre-lock)
+    const updateRes = await request(app)
+      .put("/splits/lifecycle_1/collaborators")
+      .send({
+        owner: VALID_OWNER,
+        collaborators: [
+          { address: VALID_COLLAB_A, alias: "A", basisPoints: 3000 },
+          { address: VALID_COLLAB_B, alias: "B", basisPoints: 3000 },
+          { address: VALID_COLLAB_C, alias: "C", basisPoints: 4000 }
+        ]
+      })
+      .expect(200);
+    expect(updateRes.body.metadata.operation).toBe("update_collaborators");
+    expect(updateRes.body.metadata.sourceAccount).toBe(VALID_OWNER);
+
+    // 3. Lock
+    const lockRes = await request(app)
+      .post("/splits/lifecycle_1/lock")
+      .send({ owner: VALID_OWNER })
+      .expect(200);
+    expect(lockRes.body.metadata.operation).toBe("lock_project");
+    expect(lockRes.body.metadata.sourceAccount).toBe(VALID_OWNER);
+
+    // All 3 ops called getAccount with the same owner address
+    const ownerCalls = getAccountMock.mock.calls.filter(
+      (call) => call[0] === VALID_OWNER
+    );
+    expect(ownerCalls.length).toBe(3);
+  });
+});

--- a/contracts/events.rs
+++ b/contracts/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address, Env, Event, Symbol, Val, Vec};
+use soroban_sdk::{Address, Env, Symbol};
 
 /// Emitted when a new royalty split project is created.
 ///
@@ -10,17 +10,12 @@ pub struct ProjectCreated {
     pub owner: Address,
 }
 
-impl Event for ProjectCreated {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "project_created").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        self.owner.clone().into_val(env)
+impl ProjectCreated {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "project_created"), self.project_id.clone()),
+            self.owner.clone(),
+        );
     }
 }
 
@@ -33,17 +28,12 @@ pub struct ProjectLocked {
     pub project_id: Symbol,
 }
 
-impl Event for ProjectLocked {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "project_locked").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        self.project_id.clone().into_val(env)
+impl ProjectLocked {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "project_locked"), self.project_id.clone()),
+            self.project_id.clone(),
+        );
     }
 }
 
@@ -58,17 +48,12 @@ pub struct PaymentSent {
     pub amount: i128,
 }
 
-impl Event for PaymentSent {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "payment_sent").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        (self.recipient.clone(), self.amount).into_val(env)
+impl PaymentSent {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "payment_sent"), self.project_id.clone()),
+            (self.recipient.clone(), self.amount),
+        );
     }
 }
 
@@ -83,17 +68,12 @@ pub struct DistributionComplete {
     pub total: i128,
 }
 
-impl Event for DistributionComplete {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "distribution_complete").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        (self.round, self.total).into_val(env)
+impl DistributionComplete {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "distribution_complete"), self.project_id.clone()),
+            (self.round, self.total),
+        );
     }
 }
 
@@ -109,17 +89,12 @@ pub struct DepositReceived {
     pub project_balance: i128,
 }
 
-impl Event for DepositReceived {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "deposit_received").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        (self.from.clone(), self.amount, self.project_balance).into_val(env)
+impl DepositReceived {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "deposit_received"), self.project_id.clone()),
+            (self.from.clone(), self.amount, self.project_balance),
+        );
     }
 }
 
@@ -132,17 +107,12 @@ pub struct MetadataUpdated {
     pub project_id: Symbol,
 }
 
-impl Event for MetadataUpdated {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "metadata_updated").into_val(env),
-            self.project_id.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        self.project_id.clone().into_val(env)
+impl MetadataUpdated {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "metadata_updated"), self.project_id.clone()),
+            self.project_id.clone(),
+        );
     }
 }
 
@@ -159,16 +129,16 @@ pub struct UnallocatedWithdrawn {
     pub remaining_unallocated: i128,
 }
 
-impl Event for UnallocatedWithdrawn {
-    fn topics(&self, env: &Env) -> Vec<Val> {
-        vec![
-            env,
-            Symbol::new(env, "unallocated_withdrawn").into_val(env),
-            self.token.clone().into_val(env),
-        ]
-    }
-
-    fn data(&self, env: &Env) -> Val {
-        (self.admin.clone(), self.to.clone(), self.amount, self.remaining_unallocated).into_val(env)
+impl UnallocatedWithdrawn {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "unallocated_withdrawn"), self.token.clone()),
+            (
+                self.admin.clone(),
+                self.to.clone(),
+                self.amount,
+                self.remaining_unallocated,
+            ),
+        );
     }
 }

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -82,6 +82,7 @@ pub enum DataKey {
     AllowedToken(Address),
     /// Global flag to pause all distributions (emergency stop)
     DistributionsPaused,
+}
 
 /// Returned by `get_claimable`: how much a collaborator has received and the
 /// last distribution round the project has completed.

--- a/contracts/tests.rs
+++ b/contracts/tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 use soroban_sdk::{
     testutils::{Address as _, Events as _},
-    token, Address, Env, String, Symbol, Vec, vec,
+    token, Address, Env, IntoVal, String, Symbol, Vec, vec,
 };
 
 // ============================================================
@@ -1038,27 +1038,24 @@ fn test_deposit_emits_deposit_received_event() {
     // Verify that exactly two relevant events were emitted:
     // 1) project_created  2) deposit_received (with updated project balance)
     let expected_events = vec![
+        &env,
         (
             contract_id.clone(),
-            Vec::from_slice(
+            vec![
                 &env,
-                &[
-                    Symbol::new(&env, "project_created"),
-                    project_id.clone(),
-                ],
-            ),
-            owner.clone(),
+                Symbol::new(&env, "project_created").into_val(&env),
+                project_id.clone().into_val(&env),
+            ],
+            owner.clone().into_val(&env),
         ),
         (
             contract_id.clone(),
-            Vec::from_slice(
+            vec![
                 &env,
-                &[
-                    Symbol::new(&env, "deposit_received"),
-                    project_id.clone(),
-                ],
-            ),
-            (funder.clone(), amount, amount),
+                Symbol::new(&env, "deposit_received").into_val(&env),
+                project_id.clone().into_val(&env),
+            ],
+            (funder.clone(), amount, amount).into_val(&env),
         ),
     ];
     assert_eq!(env.events().all(), expected_events);
@@ -1586,4 +1583,193 @@ fn test_withdraw_unallocated_fails_with_invalid_amount() {
 
     let result = client.try_withdraw_unallocated(&contract_admin, &token, &recovery_to, &0i128);
     assert_eq!(result, Err(Ok(SplitError::InvalidAmount)));
+}
+
+// ============================================================
+//  END-TO-END PERMISSION & LOCK LIFECYCLE TESTS
+//
+//  These tests document, in narrative form, the permission and
+//  lock rules the contract enforces. Each test reads top-to-bottom
+//  like a spec: the setup states the actors, each call states the
+//  intent, and the assertion states the rule being enforced.
+//
+//  Layers exercised:
+//    - Contract rules for owner gating (Unauthorized)
+//    - Contract rules for lock gating (ProjectLocked / AlreadyLocked)
+//    - Full lifecycle ordering (create -> edit -> lock -> reject)
+// ============================================================
+
+/// Walks the full permission lifecycle of a project in one test so the
+/// rules read as a single story:
+///   1. Owner creates the project
+///   2. Owner edits collaborators while unlocked        -> allowed
+///   3. Owner edits metadata while unlocked             -> allowed
+///   4. Owner locks the project                         -> allowed
+///   5. Owner tries to edit collaborators after lock    -> ProjectLocked
+///   6. Owner tries to edit metadata after lock         -> ProjectLocked
+///   7. Owner tries to lock again                       -> AlreadyLocked
+#[test]
+fn test_lifecycle_pre_lock_edit_lock_post_lock_reject() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let project_id = Symbol::new(&env, "lifecycle");
+
+    // 1. Owner creates the project.
+    let initial_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[6000u32, 4000u32]),
+    );
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Lifecycle Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &initial_collabs,
+    );
+
+    // 2. Owner edits collaborators while unlocked — allowed.
+    let updated_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone(), carol.clone()]),
+        Vec::from_slice(&env, &[5000u32, 3000u32, 2000u32]),
+    );
+    client.update_collaborators(&project_id, &owner, &updated_collabs);
+    let after_edit = client.get_project(&project_id).unwrap();
+    assert_eq!(after_edit.collaborators.len(), 3);
+    assert_eq!(after_edit.locked, false);
+
+    // 3. Owner edits metadata while unlocked — allowed.
+    client.update_project_metadata(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "Lifecycle Project (renamed)"),
+        &String::from_str(&env, "film"),
+    );
+    let after_metadata = client.get_project(&project_id).unwrap();
+    assert_eq!(
+        after_metadata.title,
+        String::from_str(&env, "Lifecycle Project (renamed)")
+    );
+    assert_eq!(
+        after_metadata.project_type,
+        String::from_str(&env, "film")
+    );
+
+    // 4. Owner locks the project — allowed.
+    client.lock_project(&project_id, &owner);
+    let locked = client.get_project(&project_id).unwrap();
+    assert_eq!(locked.locked, true);
+
+    // 5. Owner tries to edit collaborators after lock — ProjectLocked.
+    let post_lock_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[7000u32, 3000u32]),
+    );
+    let collab_result =
+        client.try_update_collaborators(&project_id, &owner, &post_lock_collabs);
+    assert_eq!(collab_result, Err(Ok(SplitError::ProjectLocked)));
+
+    // 6. Owner tries to edit metadata after lock — ProjectLocked.
+    let metadata_result = client.try_update_project_metadata(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "Tampered Title"),
+        &String::from_str(&env, "art"),
+    );
+    assert_eq!(metadata_result, Err(Ok(SplitError::ProjectLocked)));
+
+    // 7. Owner tries to lock again — AlreadyLocked.
+    let relock_result = client.try_lock_project(&project_id, &owner);
+    assert_eq!(relock_result, Err(Ok(SplitError::AlreadyLocked)));
+}
+
+/// Non-owner cannot lock a project. Contract returns Unauthorized
+/// before the signature check has any effect.
+#[test]
+fn test_non_owner_cannot_lock_project() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let not_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let project_id = Symbol::new(&env, "lock_unauth");
+
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Lock Unauthorized"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+
+    // Attacker attempts to lock — must be rejected.
+    let result = client.try_lock_project(&project_id, &not_owner);
+    assert_eq!(result, Err(Ok(SplitError::Unauthorized)));
+
+    // And the project must still be unlocked afterwards.
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.locked, false);
+}
+
+/// Non-owner cannot update collaborators. Contract returns Unauthorized.
+#[test]
+fn test_non_owner_cannot_update_collaborators() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let not_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let project_id = Symbol::new(&env, "collab_unauth");
+
+    let original_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Collab Unauthorized"),
+        &String::from_str(&env, "music"),
+        &token,
+        &original_collabs,
+    );
+
+    // Attacker-chosen collaborator set — should never be applied.
+    let attacker_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob, carol]),
+        Vec::from_slice(&env, &[1000u32, 1000u32, 8000u32]),
+    );
+    let result =
+        client.try_update_collaborators(&project_id, &not_owner, &attacker_collabs);
+    assert_eq!(result, Err(Ok(SplitError::Unauthorized)));
+
+    // And the original collaborator set must be intact.
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.collaborators.len(), 2);
+    assert_eq!(project.collaborators.get(0u32).unwrap().basis_points, 5000u32);
+    assert_eq!(project.collaborators.get(1u32).unwrap().basis_points, 5000u32);
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@eslint/js": "latest",
         "@tailwindcss/postcss": "latest",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "latest",
         "@testing-library/react": "latest",
         "@testing-library/user-event": "latest",
@@ -2109,7 +2110,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2130,7 +2130,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2220,8 +2219,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2729,7 +2727,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3531,7 +3528,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3564,8 +3560,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5593,7 +5588,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6134,7 +6128,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6150,7 +6143,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6163,8 +6155,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,24 +20,25 @@
   },
   "devDependencies": {
     "@eslint/js": "latest",
-    "@typescript-eslint/eslint-plugin": "latest",
-    "@typescript-eslint/parser": "latest",
-    "@types/node": "latest",
-    "@types/react": "latest",
+    "@tailwindcss/postcss": "latest",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "latest",
     "@testing-library/react": "latest",
     "@testing-library/user-event": "latest",
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@typescript-eslint/eslint-plugin": "latest",
+    "@typescript-eslint/parser": "latest",
     "autoprefixer": "latest",
-    "@tailwindcss/postcss": "latest",
     "eslint": "latest",
     "eslint-plugin-jsx-a11y": "latest",
     "eslint-plugin-react": "latest",
     "eslint-plugin-react-hooks": "latest",
     "globals": "latest",
+    "jsdom": "latest",
     "postcss": "latest",
     "tailwindcss": "latest",
     "typescript": "latest",
-    "vitest": "latest",
-    "jsdom": "latest"
+    "vitest": "latest"
   }
 }

--- a/frontend/src/components/split-app.test.tsx
+++ b/frontend/src/components/split-app.test.tsx
@@ -167,6 +167,97 @@ describe("SplitApp lock project flow", () => {
   });
 });
 
+// ============================================================
+//  ISSUE #174 — Owner-gating & Lock Lifecycle UI Tests
+// ============================================================
+
+describe("Issue #174: owner gating and lock lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: true,
+      address: "GOWNER123",
+      network: "testnet"
+    });
+    mocks.mockGetProjectHistory.mockResolvedValue([]);
+    mocks.mockGetSplit.mockResolvedValue(baseProject);
+    mocks.mockSignWithFreighter.mockResolvedValue("SIGNED_XDR");
+    mocks.mockBuildLockProjectXdr.mockResolvedValue({
+      xdr: "LOCK_XDR",
+      metadata: { networkPassphrase: "TESTNET", contractId: "CID" }
+    });
+    mocks.mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "LIFECYCLE_HASH" });
+  });
+
+  it("non-owner without wallet connection cannot see lock button and sees no locked banner on unlocked project", async () => {
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: false,
+      address: null,
+      network: null
+    });
+
+    await loadProject();
+    expect(screen.queryByRole("button", { name: "Lock Project" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Split locked - immutable")).not.toBeInTheDocument();
+  });
+
+  it("non-owner with wallet connected to a different address cannot lock", async () => {
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: true,
+      address: "GATTACKER_NOT_OWNER",
+      network: "testnet"
+    });
+
+    await loadProject();
+    expect(screen.queryByRole("button", { name: "Lock Project" })).not.toBeInTheDocument();
+  });
+
+  it("owner sees both lock button AND no locked banner on unlocked project", async () => {
+    await loadProject();
+    expect(screen.getByRole("button", { name: "Lock Project" })).toBeInTheDocument();
+    expect(screen.queryByText("Split locked - immutable")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Locked state active/)).not.toBeInTheDocument();
+  });
+
+  it("locked project shows both locked-immutable badge and 'Locked state active' secondary message", async () => {
+    mocks.mockGetSplit.mockResolvedValue({ ...baseProject, locked: true });
+
+    await loadProject();
+    expect(screen.getByText("Split locked - immutable")).toBeInTheDocument();
+    expect(screen.getByText(/Locked state active/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Lock Project" })).not.toBeInTheDocument();
+  });
+
+  it("lifecycle: confirming the lock modal invokes buildLockProjectXdr with owner address and project id", async () => {
+    const user = await loadProject();
+    expect(screen.getByRole("button", { name: "Lock Project" })).toBeInTheDocument();
+    expect(screen.queryByText("Split locked - immutable")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Lock Project" }));
+    const dialog = screen.getByRole("dialog");
+    await user.click(within(dialog).getByRole("button", { name: "Lock Project" }));
+
+    await waitFor(() => {
+      expect(mocks.mockBuildLockProjectXdr).toHaveBeenCalledWith("project_1", "GOWNER123");
+    });
+    // Owner address is forwarded to the backend so the contract's owner-gating check can reject non-owners.
+    expect(mocks.mockBuildLockProjectXdr).toHaveBeenCalledTimes(1);
+  });
+
+  it("even a non-owner viewing a locked project sees the locked banner (observer view)", async () => {
+    mocks.mockGetFreighterWalletState.mockResolvedValue({
+      connected: true,
+      address: "GRANDOM_USER",
+      network: "testnet"
+    });
+    mocks.mockGetSplit.mockResolvedValue({ ...baseProject, locked: true });
+
+    await loadProject();
+    expect(screen.getByText("Split locked - immutable")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Lock Project" })).not.toBeInTheDocument();
+  });
+});
+
 describe("SplitApp distribute flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
Closes #174

---

#174 

   ## implemented end-to-end coverage for lock and update permissions and owner gating

  ### Contract (`contracts/tests.rs`) — 3 new tests
  - `test_lifecycle_pre_lock_edit_lock_post_lock_reject` — narrative walkthrough: create → update collabs → update metadata → lock → assert post-lock edits rejected with `ProjectLocked` → assert re-lock rejected with `AlreadyLocked`
  - `test_non_owner_cannot_lock_project` — attacker calls `lock_project` → `Unauthorized`; asserts project remains unlocked
  - `test_non_owner_cannot_update_collaborators` — attacker calls `update_collaborators` → `Unauthorized`; asserts original 50/50 split preserved

  ### Backend (`backend/src/routes/splits.test.ts`) — 10 new tests
  Under `describe("Issue #174: lock & update permissions and owner gating")`:
  - Lock route: owner passthrough as `sourceAccount`; 400 on missing owner; 400 on invalid projectId; 400 surfacing "owner account not found" when RPC lookup fails
  - Update-collaborators route: owner passthrough; 400 on missing owner, bad basisPoints sum, duplicates, <2 collaborators
  - Full lifecycle: same owner drives create → update → lock end-to-end, verifying all three calls carry the same owner address

  ### Frontend (`frontend/src/components/split-app.test.tsx`) — 6 new tests
  Under `describe("Issue #174: owner gating and lock lifecycle")`:
  - Disconnected wallet: no Lock button, no locked banner on unlocked project
  - Wrong-address wallet: no Lock button
  - Owner on unlocked project: Lock button present, no locked indicators
  - Locked project: `Split locked - immutable` + `Locked state active` rendered; Lock button hidden
  - Lock confirmation: calls `buildLockProjectXdr("project_1", "GOWNER123")` (owner forwarded so contract gating can reject non-owners)
  - Non-owner viewing a locked project still sees the locked banner (observer view)

  ## Pre-existing bugs fixed inline (to unblock the test suite)

  The test suite did not compile on `main` before this PR. Three pre-existing issues were fixed inline so CI can run. Happy to split these into a separate PR if reviewers prefer:

  1. **`contracts/lib.rs:85`** — the `DataKey` enum was missing its closing `}`. File would not parse.
  2. **`contracts/events.rs`** — used `soroban_sdk::contractevent` macro and `Event` trait, neither of which exist in the pinned `soroban-sdk = "20.0.0"` (resolved to 20.5.0). Rewrote each event struct with an inherent `publish(&self,
   env: &Env)` method using the current `env.events().publish(topics, data)` API. Call sites in `lib.rs` already used `.publish(&env)` so no call-site changes needed.
  3. **`contracts/tests.rs:1-7`** — `vec![...]` in the event-assertion test used std's macro where the soroban `vec!` macro (with `&env` prefix) is required. Added `IntoVal` import and fixed the shape of `expected_events` so the types
   match `env.events().all()`.

  ## Pre-existing broken tests skipped (out of scope)

  Three existing tests fail/crash independently of this PR and are skipped in local runs:
  - `test_deposit_emits_deposit_received_event` — event-equality assertion mixes in token-contract events
  - `test_distribute_fails_when_paused`, `test_pause_and_unpause_distributions` — `STATUS_STACK_BUFFER_OVERRUN` on Windows (likely a soroban-sdk issue with `distribute` under paused state)
