### PR TITLE
feat: Admin routes, read-result caching, recovery console, and E2E tests

### DIFF
--- a/backend/src/__tests__/e2e-happy-path.test.ts
+++ b/backend/src/__tests__/e2e-happy-path.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Issue #173: End-to-end happy-path test
+ *
+ * Exercises the full core product loop in one flow:
+ *   create project → deposit → distribute → history
+ *
+ * All Stellar RPC calls are mocked so the suite is reproducible in CI
+ * without requiring a live testnet. Each step asserts the contract
+ * integration point that would break if any layer changed its contract.
+ *
+ * If a step fails the error message identifies which layer broke
+ * (validation, RPC build, or response shape) so contributors can
+ * triage quickly.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import request from "supertest";
+import { nativeToScVal } from "@stellar/stellar-sdk";
+
+import { app } from "../index.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be created before vi.mock factories are invoked
+// ---------------------------------------------------------------------------
+const { getAccountMock, prepareTransactionMock, simulateTransactionMock, getEventsMock } =
+  vi.hoisted(() => ({
+    getAccountMock: vi.fn(),
+    prepareTransactionMock: vi.fn(),
+    simulateTransactionMock: vi.fn(),
+    getEventsMock: vi.fn()
+  }));
+
+const serverMock = {
+  getAccount: getAccountMock,
+  prepareTransaction: prepareTransactionMock,
+  simulateTransaction: simulateTransactionMock,
+  getEvents: getEventsMock
+};
+
+// ---------------------------------------------------------------------------
+// Mock the Stellar SDK so zod address schemas accept our test fixtures,
+// and so rpc.Server calls are intercepted by serverMock.
+// This mirrors the approach used in splits.test.ts.
+// ---------------------------------------------------------------------------
+vi.mock("@stellar/stellar-sdk", () => {
+  class ScMapEntry {
+    key: unknown;
+    val: unknown;
+    constructor({ key, val }: { key: unknown; val: unknown }) {
+      this.key = key;
+      this.val = val;
+    }
+  }
+
+  // Import the real nativeToScVal / scValToNative so that the history decode
+  // helpers and event-value construction in tests work correctly.
+  const { nativeToScVal: realNativeToScVal, scValToNative: realScValToNative } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("@stellar/stellar-sdk") as typeof import("@stellar/stellar-sdk");
+
+  return {
+    Address: {
+      fromString: vi.fn((address: string) => ({
+        toScVal: () => ({ address })
+      }))
+    },
+    BASE_FEE: 100,
+    Contract: vi.fn().mockImplementation(() => ({
+      call: (method: string, ...args: unknown[]) => ({ method, args })
+    })),
+    TransactionBuilder: vi.fn().mockImplementation(() => ({
+      addOperation: function (op: unknown) {
+        this.op = op;
+        return this;
+      },
+      setTimeout: function () {
+        return this;
+      },
+      build: function () {
+        return { preparedOperation: this.op };
+      }
+    })),
+    nativeToScVal: realNativeToScVal,
+    scValToNative: realScValToNative,
+    rpc: {
+      Server: vi.fn(() => serverMock)
+    },
+    xdr: {
+      ScVal: {
+        scvMap: (items: unknown[]) => items,
+        scvU32: (value: number) => value,
+        scvVec: (items: unknown[]) => items
+      },
+      ScMapEntry
+    }
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock the Stellar service layer
+// ---------------------------------------------------------------------------
+vi.mock("../services/stellar.js", () => {
+  class RequestValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "RequestValidationError";
+    }
+  }
+
+  return {
+    loadStellarConfig: () => ({
+      horizonUrl: "http://horizon.test",
+      sorobanRpcUrl: "http://rpc.test",
+      networkPassphrase: "Test SDF Network",
+      contractId: "CTEST000000000000000000000000000000000000000000000000TEST",
+      simulatorAccount: "GSIMULATOR"
+    }),
+    getStellarRpcServer: () => serverMock,
+    executeWithRetry: async <T>(fn: () => Promise<T>) => fn(),
+    RequestValidationError,
+    // Cache stubs — no-ops so tests remain stateless
+    getCached: () => undefined,
+    setCached: () => undefined,
+    invalidateCache: () => undefined,
+    invalidateCacheByPrefix: () => undefined,
+    getCacheStats: () => ({ size: 0, keys: [] }),
+    READ_CACHE_TTL_MS: 30_000
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const OWNER = "GOWNER000000000000000000000000000000000000000000000000001";
+const TOKEN = "CTOKEN00000000000000000000000000000000000000000000000001";
+const COLLAB_A = "GCOLLAB0000000000000000000000000000000000000000000000001";
+const COLLAB_B = "GCOLLAB0000000000000000000000000000000000000000000000002";
+const PROJECT_ID = "e2e_happy_001";
+const DEPOSIT_AMOUNT = 10_000_000; // 1 XLM in stroops
+
+const createPayload = {
+  owner: OWNER,
+  projectId: PROJECT_ID,
+  title: "E2E Happy Path Project",
+  projectType: "music",
+  token: TOKEN,
+  collaborators: [
+    { address: COLLAB_A, alias: "Artist A", basisPoints: 6000 },
+    { address: COLLAB_B, alias: "Artist B", basisPoints: 4000 }
+  ]
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeXdrMock(operation: string, xdrString: string) {
+  return {
+    toXDR: () => xdrString,
+    sequence: "1",
+    fee: "100"
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+describe("E2E happy path: create → deposit → distribute → history", () => {
+  beforeAll(() => {
+    process.env.HORIZON_URL = "https://horizon.test";
+    process.env.SOROBAN_RPC_URL = "https://soroban.test";
+    process.env.SOROBAN_NETWORK_PASSPHRASE = "Test SDF Network";
+    process.env.CONTRACT_ID = "CTEST000000000000000000000000000000000000000000000000TEST";
+    process.env.SIMULATOR_ACCOUNT = "GSIMULATOR";
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Step 1: Create ──────────────────────────────────────────────────────
+
+  it("Step 1 — builds a create_project transaction for a valid split", async () => {
+    getAccountMock.mockResolvedValue({ accountId: OWNER });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("create_project", "XDR_CREATE_E2E"));
+
+    const res = await request(app).post("/splits").send(createPayload);
+
+    expect(res.status, `[create] unexpected status: ${JSON.stringify(res.body)}`).toBe(200);
+    expect(res.body.xdr).toBe("XDR_CREATE_E2E");
+    expect(res.body.metadata).toMatchObject({
+      operation: "create_project",
+      sourceAccount: OWNER
+    });
+
+    // Verify the RPC was called with the owner account (auth source)
+    expect(getAccountMock).toHaveBeenCalledWith(OWNER);
+  });
+
+  it("Step 1 — rejects creation with mismatched basis points (not 10000)", async () => {
+    const badPayload = {
+      ...createPayload,
+      collaborators: [
+        { address: COLLAB_A, alias: "A", basisPoints: 5000 },
+        { address: COLLAB_B, alias: "B", basisPoints: 3000 } // total 8000
+      ]
+    };
+
+    const res = await request(app).post("/splits").send(badPayload);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  // ── Step 2: Deposit ─────────────────────────────────────────────────────
+
+  it("Step 2 — builds a deposit transaction after project creation", async () => {
+    getAccountMock.mockResolvedValue({ accountId: COLLAB_A });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("deposit", "XDR_DEPOSIT_E2E"));
+
+    const res = await request(app)
+      .post(`/splits/${PROJECT_ID}/deposit`)
+      .send({ from: COLLAB_A, amount: DEPOSIT_AMOUNT });
+
+    expect(res.status, `[deposit] unexpected status: ${JSON.stringify(res.body)}`).toBe(200);
+    expect(res.body.xdr).toBe("XDR_DEPOSIT_E2E");
+    expect(res.body.metadata).toMatchObject({
+      operation: "deposit",
+      sourceAccount: COLLAB_A
+    });
+
+    expect(getAccountMock).toHaveBeenCalledWith(COLLAB_A);
+  });
+
+  it("Step 2 — rejects a deposit with amount ≤ 0", async () => {
+    const res = await request(app)
+      .post(`/splits/${PROJECT_ID}/deposit`)
+      .send({ from: COLLAB_A, amount: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  // ── Step 3: Distribute ──────────────────────────────────────────────────
+
+  it("Step 3 — builds a distribute transaction after deposit is confirmed", async () => {
+    getAccountMock.mockResolvedValue({ accountId: COLLAB_A });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("distribute", "XDR_DISTRIBUTE_E2E"));
+
+    const res = await request(app)
+      .post(`/splits/${PROJECT_ID}/distribute`)
+      .send({ sourceAddress: COLLAB_A });
+
+    expect(res.status, `[distribute] unexpected status: ${JSON.stringify(res.body)}`).toBe(200);
+    expect(res.body.xdr).toBe("XDR_DISTRIBUTE_E2E");
+    expect(res.body.metadata).toMatchObject({
+      operation: "distribute",
+      sourceAccount: COLLAB_A
+    });
+  });
+
+  it("Step 3 — distribute falls back to simulator account when no sourceAddress given", async () => {
+    getAccountMock.mockResolvedValue({ accountId: "GSIMULATOR" });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("distribute", "XDR_DISTRIBUTE_FALLBACK"));
+
+    const res = await request(app)
+      .post(`/splits/${PROJECT_ID}/distribute`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.metadata.sourceAccount).toBe("GSIMULATOR");
+  });
+
+  // ── Step 4: History ─────────────────────────────────────────────────────
+
+  it("Step 4 — returns distribution and payment events for the project", async () => {
+    const topicProjectId = nativeToScVal(PROJECT_ID, { type: "symbol" }).toXDR("base64");
+    const roundTopic = nativeToScVal("distribution_complete", { type: "symbol" }).toXDR("base64");
+    const paymentTopic = nativeToScVal("payment_sent", { type: "symbol" }).toXDR("base64");
+
+    getEventsMock
+      .mockResolvedValueOnce({
+        // distribution_complete event
+        events: [
+          {
+            value: nativeToScVal([1, BigInt(DEPOSIT_AMOUNT)]),
+            txHash: "TXHASH_ROUND_1",
+            ledgerClosedAt: "2026-04-01T10:00:00Z",
+            id: "round-event-1"
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        // payment_sent events (two collaborators)
+        events: [
+          {
+            value: nativeToScVal([COLLAB_A, BigInt(6_000_000)]),
+            txHash: "TXHASH_PAYMENT_A",
+            ledgerClosedAt: "2026-04-01T10:00:01Z",
+            id: "payment-event-a"
+          },
+          {
+            value: nativeToScVal([COLLAB_B, BigInt(4_000_000)]),
+            txHash: "TXHASH_PAYMENT_B",
+            ledgerClosedAt: "2026-04-01T10:00:01Z",
+            id: "payment-event-b"
+          }
+        ]
+      });
+
+    const res = await request(app).get(`/splits/${PROJECT_ID}/history`);
+
+    expect(res.status, `[history] unexpected status: ${JSON.stringify(res.body)}`).toBe(200);
+    expect(res.body.items).toHaveLength(3);
+
+    const roundEvent = res.body.items.find((e: { type: string }) => e.type === "round");
+    expect(roundEvent, "[history] distribution_complete event missing").toBeDefined();
+    expect(roundEvent.round).toBe(1);
+    expect(roundEvent.txHash).toBe("TXHASH_ROUND_1");
+
+    const paymentEvents = res.body.items.filter((e: { type: string }) => e.type === "payment");
+    expect(paymentEvents, "[history] payment_sent events missing").toHaveLength(2);
+
+    const collabAPayment = paymentEvents.find((e: { recipient: string }) => e.recipient === COLLAB_A);
+    expect(collabAPayment, "[history] COLLAB_A payment event missing").toBeDefined();
+    expect(collabAPayment.amount).toBe("6000000");
+
+    // Both event-fetch calls must use the correct topic filters for the project
+    expect(getEventsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [{ type: "contract", contractIds: expect.any(Array), topics: [[roundTopic], [topicProjectId]] }]
+      })
+    );
+    expect(getEventsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filters: [{ type: "contract", contractIds: expect.any(Array), topics: [[paymentTopic], [topicProjectId]] }]
+      })
+    );
+  });
+
+  it("Step 4 — returns an empty history before any distribution events exist", async () => {
+    getEventsMock.mockResolvedValue({ events: [] });
+
+    const res = await request(app).get(`/splits/${PROJECT_ID}/history`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(0);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  // ── Full flow assertion ──────────────────────────────────────────────────
+
+  it("Full flow — all four steps succeed in sequence without errors", async () => {
+    // Step 1: create
+    getAccountMock.mockResolvedValue({ accountId: OWNER });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("create_project", "XDR_FULL_CREATE"));
+    const createRes = await request(app).post("/splits").send(createPayload);
+    expect(createRes.status, `[full-flow create] ${JSON.stringify(createRes.body)}`).toBe(200);
+
+    // Step 2: deposit
+    getAccountMock.mockResolvedValue({ accountId: COLLAB_A });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("deposit", "XDR_FULL_DEPOSIT"));
+    const depositRes = await request(app)
+      .post(`/splits/${PROJECT_ID}/deposit`)
+      .send({ from: COLLAB_A, amount: DEPOSIT_AMOUNT });
+    expect(depositRes.status, `[full-flow deposit] ${JSON.stringify(depositRes.body)}`).toBe(200);
+
+    // Step 3: distribute
+    getAccountMock.mockResolvedValue({ accountId: "GSIMULATOR" });
+    prepareTransactionMock.mockResolvedValue(makeXdrMock("distribute", "XDR_FULL_DISTRIBUTE"));
+    const distributeRes = await request(app)
+      .post(`/splits/${PROJECT_ID}/distribute`)
+      .send({});
+    expect(distributeRes.status, `[full-flow distribute] ${JSON.stringify(distributeRes.body)}`).toBe(200);
+
+    // Step 4: history
+    getEventsMock
+      .mockResolvedValueOnce({
+        events: [
+          {
+            value: nativeToScVal([1, BigInt(DEPOSIT_AMOUNT)]),
+            txHash: "TXHASH_FULL_ROUND",
+            ledgerClosedAt: "2026-04-01T12:00:00Z",
+            id: "full-round-1"
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        events: [
+          {
+            value: nativeToScVal([COLLAB_A, BigInt(6_000_000)]),
+            txHash: "TXHASH_FULL_PAY_A",
+            ledgerClosedAt: "2026-04-01T12:00:01Z",
+            id: "full-payment-a"
+          }
+        ]
+      });
+
+    const historyRes = await request(app).get(`/splits/${PROJECT_ID}/history`);
+    expect(historyRes.status, `[full-flow history] ${JSON.stringify(historyRes.body)}`).toBe(200);
+    expect(historyRes.body.items.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/routes/splits.test.ts
+++ b/backend/src/routes/splits.test.ts
@@ -674,3 +674,153 @@ describe("Issue #174: lock & update permissions and owner gating", () => {
     expect(ownerCalls.length).toBe(3);
   });
 });
+
+// ============================================================
+// Issue #152: Admin contract-state read routes
+// ============================================================
+
+describe("admin contract-state read routes", () => {
+  it("GET /splits/admin/status returns admin address and pause status", async () => {
+    simulateTransactionMock.mockResolvedValue({
+      result: { retval: "GADMIN" }
+    });
+    getAccountMock.mockResolvedValue({ accountId: "GTESTSIMULATOR" });
+
+    const app = createApp();
+    const res = await request(app).get("/splits/admin/status").expect(200);
+
+    expect(res.body).toHaveProperty("admin");
+    expect(res.body).toHaveProperty("isPaused");
+  });
+
+  it("GET /splits/admin/is-token-allowed returns allowlist status for a valid token", async () => {
+    simulateTransactionMock.mockResolvedValue({
+      result: { retval: true }
+    });
+    getAccountMock.mockResolvedValue({ accountId: "GTESTSIMULATOR" });
+
+    const app = createApp();
+    const token = "CTOKEN00000000000000000000000000000000000000000000000001";
+    const res = await request(app)
+      .get(`/splits/admin/is-token-allowed?token=${token}`)
+      .expect(200);
+
+    expect(res.body).toMatchObject({ token });
+    expect(res.body).toHaveProperty("isAllowed");
+  });
+
+  it("GET /splits/admin/is-token-allowed returns 400 for a missing token param", async () => {
+    const app = createApp();
+    const res = await request(app).get("/splits/admin/is-token-allowed").expect(400);
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  it("GET /splits/admin/token-count returns allowed token count", async () => {
+    simulateTransactionMock.mockResolvedValue({
+      result: { retval: 3 }
+    });
+    getAccountMock.mockResolvedValue({ accountId: "GTESTSIMULATOR" });
+
+    const app = createApp();
+    const res = await request(app).get("/splits/admin/token-count").expect(200);
+
+    expect(res.body).toHaveProperty("count");
+  });
+});
+
+// ============================================================
+// Issue #166: Unallocated token recovery routes
+// ============================================================
+
+describe("unallocated token recovery routes", () => {
+  const VALID_ADMIN = "GADMIN00000000000000000000000000000000000000000000000001";
+  const VALID_TOKEN = "CTOKEN00000000000000000000000000000000000000000000000001";
+  const VALID_TO = "GRECOVER0000000000000000000000000000000000000000000000001";
+
+  it("GET /splits/admin/unallocated returns recoverable balance for a valid token", async () => {
+    simulateTransactionMock.mockResolvedValue({
+      result: { retval: 500_000 }
+    });
+    getAccountMock.mockResolvedValue({ accountId: "GTESTSIMULATOR" });
+
+    const app = createApp();
+    const res = await request(app)
+      .get(`/splits/admin/unallocated?token=${VALID_TOKEN}`)
+      .expect(200);
+
+    expect(res.body).toMatchObject({ token: VALID_TOKEN });
+    expect(res.body).toHaveProperty("unallocated");
+  });
+
+  it("GET /splits/admin/unallocated returns 400 when token is missing", async () => {
+    const app = createApp();
+    const res = await request(app).get("/splits/admin/unallocated").expect(400);
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  it("POST /splits/admin/withdraw-unallocated builds unsigned XDR with audit context", async () => {
+    getAccountMock.mockResolvedValue({ accountId: VALID_ADMIN });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "XDR_WITHDRAW_UNALLOCATED",
+      sequence: "999",
+      fee: "100"
+    });
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/admin/withdraw-unallocated")
+      .send({
+        admin: VALID_ADMIN,
+        token: VALID_TOKEN,
+        to: VALID_TO,
+        amount: 250_000
+      })
+      .expect(200);
+
+    expect(res.body.xdr).toBe("XDR_WITHDRAW_UNALLOCATED");
+    expect(res.body.metadata.operation).toBe("withdraw_unallocated");
+    expect(res.body.metadata.auditContext).toMatchObject({
+      token: VALID_TOKEN,
+      destination: VALID_TO,
+      amount: 250_000
+    });
+    expect(res.body.metadata.auditContext.initiatedAt).toBeDefined();
+    expect(getAccountMock).toHaveBeenCalledWith(VALID_ADMIN);
+  });
+
+  it("POST /splits/admin/withdraw-unallocated returns 400 when amount is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/admin/withdraw-unallocated")
+      .send({ admin: VALID_ADMIN, token: VALID_TOKEN, to: VALID_TO })
+      .expect(400);
+
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  it("POST /splits/admin/withdraw-unallocated returns 400 when amount is zero or negative", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/admin/withdraw-unallocated")
+      .send({ admin: VALID_ADMIN, token: VALID_TOKEN, to: VALID_TO, amount: -1 })
+      .expect(400);
+
+    expect(res.body.error).toBe("validation_error");
+  });
+});
+
+// ============================================================
+// Issue #161: Read-result caching — cache-stats endpoint
+// ============================================================
+
+describe("cache stats endpoint", () => {
+  it("GET /splits/admin/cache-stats returns cache size and ttl", async () => {
+    const app = createApp();
+    const res = await request(app).get("/splits/admin/cache-stats").expect(200);
+
+    expect(res.body).toHaveProperty("size");
+    expect(res.body).toHaveProperty("ttlMs");
+    expect(res.body).toHaveProperty("keys");
+    expect(Array.isArray(res.body.keys)).toBe(true);
+  });
+});

--- a/backend/src/routes/splits.ts
+++ b/backend/src/routes/splits.ts
@@ -15,7 +15,13 @@ import {
   loadStellarConfig, 
   getStellarRpcServer, 
   RequestValidationError,
-  executeWithRetry
+  executeWithRetry,
+  getCached,
+  setCached,
+  invalidateCache,
+  invalidateCacheByPrefix,
+  getCacheStats,
+  READ_CACHE_TTL_MS
 } from "../services/stellar.js";
 
 export const splitsRouter = Router();
@@ -382,6 +388,12 @@ async function simulateReadOnlyContractCall(
 }
 
 async function listProjects(start: number, limit: number) {
+  const cacheKey = `list_projects:${start}:${limit}`;
+  const cached = getCached<unknown[]>(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const config = loadStellarConfig();
   const server = getStellarRpcServer();
 
@@ -409,10 +421,18 @@ async function listProjects(start: number, limit: number) {
     return [];
   }
 
-  return scValToNative(retval) as unknown[];
+  const result = scValToNative(retval) as unknown[];
+  setCached(cacheKey, result);
+  return result;
 }
 
 async function fetchProjectById(projectId: string) {
+  const cacheKey = `project:${projectId}`;
+  const cached = getCached<unknown>(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
   const config = loadStellarConfig();
   const server = getStellarRpcServer();
 
@@ -439,7 +459,11 @@ async function fetchProjectById(projectId: string) {
   }
 
   const project = scValToNative(retval) as unknown;
-  return project ?? null;
+  const result = project ?? null;
+  if (result !== null) {
+    setCached(cacheKey, result);
+  }
+  return result;
 }
 
 interface LockProjectRequest {
@@ -888,6 +912,9 @@ splitsRouter.post("/:projectId/deposit", async (req, res, next) => {
         from: parsedBody.data.from,
         amount: parsedBody.data.amount
       });
+      // Evict cached project state; balance will change after submission
+      invalidateCache(`project:${parsedParams.data}`);
+      invalidateCacheByPrefix("list_projects:");
       return res.status(200).json(result);
     } catch (error) {
       if (error instanceof RequestValidationError) {
@@ -1002,6 +1029,8 @@ splitsRouter.post("/", async (req, res, next) => {
 
     try {
       const result = await buildCreateProjectUnsignedXdr(parsed.data);
+      // Invalidate list cache so newly created project appears immediately
+      invalidateCacheByPrefix("list_projects:");
       return res.status(200).json(result);
     } catch (error) {
       if (error instanceof RequestValidationError) {
@@ -1072,6 +1101,10 @@ splitsRouter.post("/:projectId/distribute", async (req: Request, res: Response, 
       .build();
 
     const preparedTx = await executeWithRetry(() => server.prepareTransaction(tx));
+
+    // Evict cached project data; distribution round and balance will change
+    invalidateCache(`project:${projectId}`);
+    invalidateCacheByPrefix("list_projects:");
 
     return res.status(200).json({
       xdr: preparedTx.toXDR(),
@@ -1449,7 +1482,7 @@ export const historyQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(100)
 });
 
-function toEventTopic(value: string) {
+function _toEventTopic(value: string) {
   const scVal = nativeToScVal(value, { type: "symbol" });
   return typeof scVal === "object" && scVal !== null && "toXDR" in scVal
     ? scVal.toXDR("base64")
@@ -1550,4 +1583,253 @@ splitsRouter.get("/:projectId/history", async (req: Request, res: Response, next
   } catch (error) {
     return next(error);
   }
+});
+
+// ============================================================
+// Issue #152: Admin contract-state read routes
+// Expose get_admin, is_token_allowed, get_allowed_token_count,
+// and is_distributions_paused as cohesive read endpoints.
+// ============================================================
+
+/**
+ * GET /splits/admin/status
+ * Returns the current admin address and whether distributions are paused.
+ */
+splitsRouter.get("/admin/status", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    try {
+      const [adminRetval, pausedRetval] = await Promise.all([
+        simulateReadOnlyContractCall("get_admin"),
+        simulateReadOnlyContractCall("is_distributions_paused")
+      ]);
+
+      const admin = adminRetval ? String(scValToNative(adminRetval)) : null;
+      const isPaused = pausedRetval ? Boolean(scValToNative(pausedRetval)) : false;
+
+      return res.status(200).json({ admin, isPaused });
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({ error: "validation_error", message: error.message, requestId });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+const isTokenAllowedQuerySchema = z.object({
+  token: stellarAddressSchema.describe("token contract address to check")
+});
+
+/**
+ * GET /splits/admin/is-token-allowed?token=<address>
+ * Returns whether the given token is on the contract allowlist.
+ */
+splitsRouter.get("/admin/is-token-allowed", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    const parsed = isTokenAllowedQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "validation_error",
+        message: "Invalid query parameters.",
+        details: parsed.error.flatten(),
+        requestId
+      });
+    }
+    const { token } = parsed.data;
+
+    try {
+      const retval = await simulateReadOnlyContractCall("is_token_allowed", [
+        Address.fromString(token).toScVal()
+      ]);
+      const isAllowed = retval ? Boolean(scValToNative(retval)) : false;
+      return res.status(200).json({ token, isAllowed });
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({ error: "validation_error", message: error.message, requestId });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+/**
+ * GET /splits/admin/token-count
+ * Returns the current number of allowlisted tokens.
+ */
+splitsRouter.get("/admin/token-count", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    try {
+      const retval = await simulateReadOnlyContractCall("get_allowed_token_count");
+      const count = retval ? Number(scValToNative(retval)) : 0;
+      return res.status(200).json({ count });
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({ error: "validation_error", message: error.message, requestId });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// ============================================================
+// Issue #166: Unallocated token recovery routes
+// Inspect and recover tokens that landed in the contract address
+// outside of any tracked project balance.
+// ============================================================
+
+const unallocatedQuerySchema = z.object({
+  token: stellarAddressSchema.describe("token contract address")
+});
+
+/**
+ * GET /splits/admin/unallocated?token=<address>
+ * Returns the unallocated (recoverable) balance for a token in the contract.
+ */
+splitsRouter.get("/admin/unallocated", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    const parsed = unallocatedQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "validation_error",
+        message: "Invalid query parameters.",
+        details: parsed.error.flatten(),
+        requestId
+      });
+    }
+    const { token } = parsed.data;
+
+    try {
+      const retval = await simulateReadOnlyContractCall("get_unallocated_balance", [
+        Address.fromString(token).toScVal()
+      ]);
+      const unallocated = retval ? String(scValToNative(retval)) : "0";
+      return res.status(200).json({ token, unallocated });
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({ error: "validation_error", message: error.message, requestId });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+export const withdrawUnallocatedSchema = z.object({
+  admin: stellarAddressSchema.describe("admin"),
+  token: stellarAddressSchema.describe("token contract address"),
+  to: stellarAddressSchema.describe("destination address"),
+  amount: z
+    .number()
+    .positive("amount must be greater than 0")
+    .describe("amount in stroops to recover")
+});
+
+type WithdrawUnallocatedRequest = z.infer<typeof withdrawUnallocatedSchema>;
+
+async function buildWithdrawUnallocatedUnsignedXdr(input: WithdrawUnallocatedRequest) {
+  const config = loadStellarConfig();
+  const server = getStellarRpcServer();
+
+  let sourceAccount;
+  try {
+    sourceAccount = await executeWithRetry(() => server.getAccount(input.admin));
+  } catch {
+    throw new RequestValidationError("admin account not found on selected network");
+  }
+
+  const adminAddress = Address.fromString(input.admin);
+  const tokenAddress = Address.fromString(input.token);
+  const toAddress = Address.fromString(input.to);
+
+  const contract = new Contract(config.contractId);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: BASE_FEE,
+    networkPassphrase: config.networkPassphrase
+  })
+    .addOperation(
+      contract.call(
+        "withdraw_unallocated",
+        adminAddress.toScVal(),
+        tokenAddress.toScVal(),
+        toAddress.toScVal(),
+        nativeToScVal(input.amount, { type: "i128" })
+      )
+    )
+    .setTimeout(300)
+    .build();
+
+  const preparedTx = await executeWithRetry(() => server.prepareTransaction(tx));
+  return {
+    xdr: preparedTx.toXDR(),
+    metadata: {
+      contractId: config.contractId,
+      networkPassphrase: config.networkPassphrase,
+      sourceAccount: input.admin,
+      sequenceNumber: preparedTx.sequence,
+      fee: preparedTx.fee,
+      operation: "withdraw_unallocated",
+      // Audit context included so operators can later understand what was recovered
+      auditContext: {
+        token: input.token,
+        destination: input.to,
+        amount: input.amount,
+        initiatedAt: new Date().toISOString()
+      }
+    }
+  };
+}
+
+/**
+ * POST /splits/admin/withdraw-unallocated
+ * Builds an unsigned XDR transaction to recover unallocated tokens.
+ * The response includes audit context (token, destination, amount, timestamp).
+ */
+splitsRouter.post("/admin/withdraw-unallocated", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+    const parsed = withdrawUnallocatedSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: "validation_error",
+        message: "Invalid request payload.",
+        details: parsed.error.flatten(),
+        requestId
+      });
+    }
+
+    try {
+      const result = await buildWithdrawUnallocatedUnsignedXdr(parsed.data);
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return res.status(400).json({ error: "validation_error", message: error.message, requestId });
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
+
+// ============================================================
+// Cache diagnostics (non-sensitive internal endpoint)
+// ============================================================
+
+/**
+ * GET /splits/admin/cache-stats
+ * Returns current in-memory cache occupancy for operational visibility.
+ */
+splitsRouter.get("/admin/cache-stats", (_req: Request, res: Response) => {
+  res.status(200).json({ ...getCacheStats(), ttlMs: READ_CACHE_TTL_MS });
 });

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -109,3 +109,67 @@ export function getStellarRpcServer(): rpc.Server {
   cachedRpcServer = new rpc.Server(config.sorobanRpcUrl, { allowHttp: true });
   return cachedRpcServer;
 }
+
+// ============================================================
+//  READ-RESULT CACHE
+//  TTL-based in-memory cache for read-only contract simulations.
+//  Invalidation rules:
+//   - Entries expire after `ttlMs` milliseconds (default 30 s).
+//   - Write operations (create, deposit, distribute, lock, etc.)
+//     must call `invalidateCache(key)` or `invalidateCacheByPrefix(prefix)`
+//     to evict stale entries immediately.
+//   - The cache is process-local; it is automatically warm up on the first
+//     read after a cold start or after an invalidation.
+// ============================================================
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const _cache = new Map<string, CacheEntry<unknown>>();
+
+export const READ_CACHE_TTL_MS = 30_000; // 30 seconds default
+
+export function getCached<T>(key: string): T | undefined {
+  const entry = _cache.get(key) as CacheEntry<T> | undefined;
+  if (!entry) {
+    return undefined;
+  }
+  if (Date.now() > entry.expiresAt) {
+    _cache.delete(key);
+    console.debug(`[cache] MISS (expired) key=${key}`);
+    return undefined;
+  }
+  console.debug(`[cache] HIT key=${key}`);
+  return entry.value;
+}
+
+export function setCached<T>(key: string, value: T, ttlMs = READ_CACHE_TTL_MS): void {
+  _cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  console.debug(`[cache] SET key=${key} ttl=${ttlMs}ms`);
+}
+
+export function invalidateCache(key: string): void {
+  const deleted = _cache.delete(key);
+  if (deleted) {
+    console.debug(`[cache] INVALIDATE key=${key}`);
+  }
+}
+
+export function invalidateCacheByPrefix(prefix: string): void {
+  let count = 0;
+  for (const key of _cache.keys()) {
+    if (key.startsWith(prefix)) {
+      _cache.delete(key);
+      count++;
+    }
+  }
+  if (count > 0) {
+    console.debug(`[cache] INVALIDATE prefix=${prefix} removed=${count}`);
+  }
+}
+
+export function getCacheStats(): { size: number; keys: string[] } {
+  return { size: _cache.size, keys: Array.from(_cache.keys()) };
+}

--- a/frontend/src/components/split-app.tsx
+++ b/frontend/src/components/split-app.tsx
@@ -20,6 +20,9 @@ import {
   type ProjectHistoryItem,
   getTokenAllowlist,
   type TokenAllowlistState,
+  getUnallocatedBalance,
+  buildWithdrawUnallocatedXdr,
+  type UnallocatedBalanceState,
 } from "@/lib/api";
 import { isOwner } from "@/lib/address";
 import {
@@ -213,6 +216,17 @@ export function SplitApp() {
   const [isUpdatingAllowlist, setIsUpdatingAllowlist] = useState(false);
   const [lastAllowlistTx, setLastAllowlistTx] = useState<AllowlistActionResult | null>(null);
 
+  // Issue #166: Unallocated token recovery console state
+  const [recoveryTokenInput, setRecoveryTokenInput] = useState("");
+  const [recoveryToInput, setRecoveryToInput] = useState("");
+  const [recoveryAmountInput, setRecoveryAmountInput] = useState("");
+  const [unallocatedBalance, setUnallocatedBalance] = useState<UnallocatedBalanceState | null>(null);
+  const [isLoadingUnallocated, setIsLoadingUnallocated] = useState(false);
+  const [unallocatedError, setUnallocatedError] = useState<string | null>(null);
+  const [showRecoveryConfirm, setShowRecoveryConfirm] = useState(false);
+  const [isSubmittingRecovery, setIsSubmittingRecovery] = useState(false);
+  const [lastRecoveryTxHash, setLastRecoveryTxHash] = useState<string | null>(null);
+
   const totalBasisPoints = useMemo(
     () =>
       collaborators.reduce((sum, collaborator) => {
@@ -395,6 +409,75 @@ export function SplitApp() {
     // Note: useWallet doesn't have a disconnect method yet as Freighter doesn't support it well,
     // but we can refresh to get current state or just notify.
     notify.info("Freighter does not support programmatic disconnect. Use the extension to revoke access.");
+  }
+
+  // Issue #166: Inspect unallocated balance for a token
+  async function onInspectUnallocated() {
+    if (!recoveryTokenInput.trim()) {
+      notify.error("Token address is required.");
+      return;
+    }
+    setIsLoadingUnallocated(true);
+    setUnallocatedError(null);
+    setUnallocatedBalance(null);
+    setShowRecoveryConfirm(false);
+    setLastRecoveryTxHash(null);
+    try {
+      const data = await getUnallocatedBalance(recoveryTokenInput.trim());
+      setUnallocatedBalance(data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to fetch unallocated balance.";
+      setUnallocatedError(message);
+    } finally {
+      setIsLoadingUnallocated(false);
+    }
+  }
+
+  // Issue #166: Submit a recovery transaction after operator confirmation
+  async function onConfirmRecovery() {
+    if (!wallet.address || !unallocatedBalance) return;
+    const amount = Number(recoveryAmountInput.trim());
+    if (!recoveryToInput.trim() || !Number.isFinite(amount) || amount <= 0) {
+      notify.error("Destination address and a valid positive amount are required.");
+      return;
+    }
+
+    setIsSubmittingRecovery(true);
+    try {
+      const buildResponse = await buildWithdrawUnallocatedXdr({
+        admin: wallet.address,
+        token: unallocatedBalance.token,
+        to: recoveryToInput.trim(),
+        amount
+      });
+
+      const signedTxXdr = await signWithFreighter(
+        buildResponse.xdr,
+        buildResponse.metadata.networkPassphrase
+      );
+
+      const server = new rpc.Server(
+        process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org",
+        { allowHttp: true }
+      );
+      const transaction = new Transaction(signedTxXdr, buildResponse.metadata.networkPassphrase);
+      const submitResponse = await server.sendTransaction(transaction);
+
+      if (submitResponse.status === "ERROR") {
+        throw new Error(submitResponse.errorResult?.toString() ?? "Transaction failed.");
+      }
+
+      setLastRecoveryTxHash(submitResponse.hash ?? null);
+      setShowRecoveryConfirm(false);
+      notify.success("Recovery transaction submitted successfully.");
+      // Refresh the unallocated balance display
+      await onInspectUnallocated();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Recovery transaction failed.";
+      notify.error(message);
+    } finally {
+      setIsSubmittingRecovery(false);
+    }
   }
 
   async function onUpdateMetadata() {
@@ -1434,6 +1517,165 @@ export function SplitApp() {
                   ) : (
                     <div className="rounded-2xl border border-dashed border-white/10 bg-white/2 px-5 py-6 text-sm text-muted">
                       No token addresses are allowlisted yet. The contract currently accepts any token address for new splits.
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Issue #166: Unallocated Token Recovery Console */}
+            {wallet.connected && isContractAdmin && (
+              <div className="glass-card rounded-[2.5rem] p-8 md:p-10 border border-goldLight/10">
+                <div className="space-y-1 mb-8">
+                  <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-goldLight/80">
+                    Admin — Recovery Console
+                  </p>
+                  <h2 className="font-display text-2xl tracking-tight">Unallocated Token Recovery</h2>
+                  <p className="max-w-2xl text-sm text-muted">
+                    Inspect and safely recover tokens that were sent directly to the contract address
+                    outside of any tracked project balance. This action never touches project-accounted funds.
+                  </p>
+                </div>
+
+                {/* Step 1: Inspect */}
+                <div className="space-y-4">
+                  <label className="block">
+                    <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted">Token Contract Address</span>
+                    <input
+                      type="text"
+                      value={recoveryTokenInput}
+                      onChange={(e) => setRecoveryTokenInput(e.target.value)}
+                      placeholder="C..."
+                      className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 font-mono text-sm text-ink placeholder:text-muted/40 focus:outline-none focus:ring-2 focus:ring-goldLight/30"
+                    />
+                  </label>
+                  <button
+                    type="button"
+                    onClick={onInspectUnallocated}
+                    disabled={isLoadingUnallocated || !recoveryTokenInput.trim()}
+                    className="rounded-xl border border-goldLight/30 bg-goldLight/10 px-6 py-2.5 text-xs font-bold uppercase tracking-widest text-goldLight transition-all hover:bg-goldLight/20 disabled:opacity-40"
+                  >
+                    {isLoadingUnallocated ? "Inspecting…" : "Inspect Unallocated Balance"}
+                  </button>
+
+                  {unallocatedError && (
+                    <p className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+                      {unallocatedError}
+                    </p>
+                  )}
+
+                  {unallocatedBalance && (
+                    <div className="rounded-2xl border border-goldLight/20 bg-goldLight/5 p-6 space-y-4">
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="space-y-1">
+                          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-goldLight/80">Recoverable Balance</p>
+                          <p className="font-mono text-2xl font-bold text-goldLight">
+                            {Number(unallocatedBalance.unallocated).toLocaleString()}{" "}
+                            <span className="text-sm font-sans text-muted">Stroops</span>
+                          </p>
+                        </div>
+                        <div className="text-right space-y-1">
+                          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted">Token</p>
+                          <p className="font-mono text-[11px] text-muted break-all max-w-[200px]">{unallocatedBalance.token}</p>
+                        </div>
+                      </div>
+
+                      {/* Step 2: Recovery form */}
+                      {Number(unallocatedBalance.unallocated) > 0 && !showRecoveryConfirm && (
+                        <div className="space-y-3 pt-2 border-t border-white/5">
+                          <label className="block">
+                            <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted">Destination Address</span>
+                            <input
+                              type="text"
+                              value={recoveryToInput}
+                              onChange={(e) => setRecoveryToInput(e.target.value)}
+                              placeholder="G... or C..."
+                              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 font-mono text-sm text-ink placeholder:text-muted/40 focus:outline-none focus:ring-2 focus:ring-goldLight/30"
+                            />
+                          </label>
+                          <label className="block">
+                            <span className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted">Amount (Stroops)</span>
+                            <input
+                              type="number"
+                              min={1}
+                              max={Number(unallocatedBalance.unallocated)}
+                              value={recoveryAmountInput}
+                              onChange={(e) => setRecoveryAmountInput(e.target.value)}
+                              className="mt-2 w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 font-mono text-sm text-ink placeholder:text-muted/40 focus:outline-none focus:ring-2 focus:ring-goldLight/30"
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (!recoveryToInput.trim() || !recoveryAmountInput || Number(recoveryAmountInput) <= 0) {
+                                notify.error("Fill in destination address and a valid amount.");
+                                return;
+                              }
+                              setShowRecoveryConfirm(true);
+                            }}
+                            className="rounded-xl bg-goldLight/20 px-6 py-2.5 text-xs font-bold uppercase tracking-widest text-goldLight transition-all hover:bg-goldLight/30"
+                          >
+                            Review Recovery
+                          </button>
+                        </div>
+                      )}
+
+                      {/* Step 3: Confirmation dialog */}
+                      {showRecoveryConfirm && (
+                        <div className="space-y-4 rounded-2xl border border-goldLight/30 bg-black/30 p-6 pt-4">
+                          <h3 className="text-xs font-bold uppercase tracking-widest text-goldLight">
+                            Confirm Recovery — Review Before Submitting
+                          </h3>
+                          <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                            <dt className="text-muted">Token</dt>
+                            <dd className="font-mono text-[11px] break-all">{unallocatedBalance.token}</dd>
+                            <dt className="text-muted">Destination</dt>
+                            <dd className="font-mono text-[11px] break-all">{recoveryToInput}</dd>
+                            <dt className="text-muted">Amount</dt>
+                            <dd className="font-mono font-bold text-goldLight">{Number(recoveryAmountInput).toLocaleString()} Stroops</dd>
+                            <dt className="text-muted">Remaining After</dt>
+                            <dd className="font-mono">
+                              {(Number(unallocatedBalance.unallocated) - Number(recoveryAmountInput)).toLocaleString()} Stroops
+                            </dd>
+                          </dl>
+                          <p className="text-[11px] text-muted/70 italic">
+                            This action only withdraws the unallocated surplus. Project-accounted balances are never touched.
+                          </p>
+                          <div className="flex gap-3">
+                            <button
+                              type="button"
+                              onClick={onConfirmRecovery}
+                              disabled={isSubmittingRecovery}
+                              className="rounded-xl bg-goldLight/30 px-6 py-2.5 text-xs font-bold uppercase tracking-widest text-goldLight transition-all hover:bg-goldLight/40 disabled:opacity-40"
+                            >
+                              {isSubmittingRecovery ? "Submitting…" : "Confirm & Submit"}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setShowRecoveryConfirm(false)}
+                              className="rounded-xl border border-white/10 px-6 py-2.5 text-xs font-bold uppercase tracking-widest text-muted transition-all hover:text-ink"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Audit receipt after successful recovery */}
+                  {lastRecoveryTxHash && (
+                    <div className="rounded-2xl border border-greenBright/20 bg-greenBright/5 p-5">
+                      <p className="text-[10px] font-bold uppercase tracking-widest text-greenBright mb-2">Recovery Submitted</p>
+                      <p className="font-mono text-[11px] text-muted break-all">Tx: {lastRecoveryTxHash}</p>
+                      <a
+                        href={`https://stellar.expert/explorer/testnet/tx/${lastRecoveryTxHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 inline-block text-[10px] font-bold text-greenBright underline underline-offset-4 hover:text-white"
+                      >
+                        View on Explorer →
+                      </a>
                     </div>
                   )}
                 </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -236,3 +236,85 @@ export async function getTokenAllowlist(
     "Failed to fetch token allowlist"
   );
 }
+
+// ============================================================
+// Issue #152: Admin contract-state read helpers
+// ============================================================
+
+export interface AdminStatusState {
+  admin: string | null;
+  isPaused: boolean;
+}
+
+export async function getAdminStatus(): Promise<AdminStatusState> {
+  return requestJson<AdminStatusState>(
+    "/splits/admin/status",
+    "Failed to fetch admin status"
+  );
+}
+
+export async function isTokenAllowed(token: string): Promise<{ token: string; isAllowed: boolean }> {
+  return requestJson<{ token: string; isAllowed: boolean }>(
+    `/splits/admin/is-token-allowed?token=${encodeURIComponent(token)}`,
+    "Failed to check token allowlist status"
+  );
+}
+
+export async function getAdminTokenCount(): Promise<{ count: number }> {
+  return requestJson<{ count: number }>(
+    "/splits/admin/token-count",
+    "Failed to fetch allowed token count"
+  );
+}
+
+// ============================================================
+// Issue #166: Unallocated token recovery helpers
+// ============================================================
+
+export interface UnallocatedBalanceState {
+  token: string;
+  unallocated: string;
+}
+
+export async function getUnallocatedBalance(token: string): Promise<UnallocatedBalanceState> {
+  return requestJson<UnallocatedBalanceState>(
+    `/splits/admin/unallocated?token=${encodeURIComponent(token)}`,
+    "Failed to fetch unallocated balance"
+  );
+}
+
+export interface WithdrawUnallocatedPayload {
+  admin: string;
+  token: string;
+  to: string;
+  amount: number;
+}
+
+export interface WithdrawUnallocatedResponse {
+  xdr: string;
+  metadata: {
+    networkPassphrase: string;
+    contractId: string;
+    operation: string;
+    auditContext: {
+      token: string;
+      destination: string;
+      amount: number;
+      initiatedAt: string;
+    };
+  };
+}
+
+export async function buildWithdrawUnallocatedXdr(
+  payload: WithdrawUnallocatedPayload
+): Promise<WithdrawUnallocatedResponse> {
+  return requestJson<WithdrawUnallocatedResponse>(
+    "/splits/admin/withdraw-unallocated",
+    "Failed to build withdraw unallocated transaction",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    }
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements four open issues across the backend, frontend, and test layers of SplitNaira. All changes follow the project's existing code patterns and are CI-friendly.

---

## Changes

### Issue #152 — Backend: Add admin contract-state read routes

Exposes the missing contract read functions as cohesive, validated REST endpoints so operators and future frontend admin views have one place to fetch control-plane data.

**New routes:**
- `GET /splits/admin/status` — returns `{ admin, isPaused }` (calls `get_admin` + `is_distributions_paused`)
- `GET /splits/admin/is-token-allowed?token=<addr>` — returns `{ token, isAllowed }` (calls `is_token_allowed`)
- `GET /splits/admin/token-count` — returns `{ count }` (calls `get_allowed_token_count`)

All routes use validated Zod schemas and the same response envelope used elsewhere in the router.

**Tests added:** `admin contract-state read routes` describe block in `splits.test.ts`

---

### Issue #161 — Backend: Add read-result caching for repeated project simulations

Adds a TTL-based in-memory cache to `stellar.ts` so repeated `list_projects` and `get_project` simulations are served from memory instead of re-simulating on every request.

**Cache design:**
- `getCached` / `setCached` — 30-second TTL (configurable via `READ_CACHE_TTL_MS`)
- `invalidateCache(key)` / `invalidateCacheByPrefix(prefix)` — explicit invalidation on writes
- Write operations (create, deposit, distribute) call the appropriate invalidation helpers immediately after building the XDR
- `GET /splits/admin/cache-stats` — exposes cache size and key list for operational visibility
- All cache events are logged at `debug` level (`[cache] HIT/MISS/SET/INVALIDATE key=...`)

**Invalidation rules (documented inline):**
- `create` → invalidates all `list_projects:*` entries
- `deposit` → invalidates the specific `project:<id>` entry and all `list_projects:*`
- `distribute` → invalidates the specific `project:<id>` entry and all `list_projects:*`

**Tests added:** `cache stats endpoint` describe block in `splits.test.ts`

---

### Issue #166 — Fullstack: Add unallocated token recovery console

Builds the full operator workflow for recovering tokens that were sent directly to the contract address outside of any tracked project balance.

**Backend:**
- `GET /splits/admin/unallocated?token=<addr>` — simulates `get_unallocated_balance` and returns `{ token, unallocated }`
- `POST /splits/admin/withdraw-unallocated` — builds an unsigned `withdraw_unallocated` XDR; response includes `auditContext` with `{ token, destination, amount, initiatedAt }` so operators can later trace what was recovered and why

**Frontend (`api.ts`):**
- `getUnallocatedBalance(token)` — fetch helper
- `buildWithdrawUnallocatedXdr(payload)` — build helper with typed `WithdrawUnallocatedResponse`

**Frontend (`split-app.tsx`) — Recovery Console UI (visible to contract admin only):**
- Step 1: Token address input → "Inspect Unallocated Balance" shows recoverable amount
- Step 2: Destination address + amount form
- Step 3: Confirmation dialog showing token / destination / amount / remaining balance before any transaction is submitted
- Audit receipt with explorer link shown after successful submission

**Tests added:** `unallocated token recovery routes` describe block in `splits.test.ts`

---

### Issue #173 — QA: Add end-to-end coverage for create → deposit → distribute → history

Adds `backend/src/__tests__/e2e-happy-path.test.ts` — a reproducible, CI-friendly end-to-end suite that exercises the entire core product loop in a single test file.

**Coverage:**
- Step 1 (Create): valid payload builds XDR; invalid basis-point split is rejected with 400
- Step 2 (Deposit): valid deposit builds XDR; amount ≤ 0 is rejected
- Step 3 (Distribute): distribute builds XDR with explicit source; falls back to simulator account when none given
- Step 4 (History): round and payment events are decoded, topic-filtered, and returned in the correct shape
- **Full-flow test**: all four steps succeed in sequence with no errors between them

All Stellar RPC calls are mocked (no live testnet required). Failure messages include the step name and response body so contributors can see which layer broke.

---

## Pre-existing issues (not introduced by this PR)

The following test/lint failures exist on `main` and are unaffected by this PR:
- `routes.test.ts` — two assertions have wrong status expectations (pre-existing)
- `rpc-retries.test.ts` — timeout test is flaky at the default 5 s limit (pre-existing)
- Frontend ESLint — `zod/v4/core` package path error in Node 22 (pre-existing environment issue)
- Frontend `useNetworkGuard.test.ts` — 6 assertion failures (pre-existing)

---

Closes #152
Closes #161
Closes #166
Closes #173