### PR TITLE
feat(backend): add Winston logger, PostgreSQL with TypeORM, and User model

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,5 +1,7 @@
-﻿PORT=3001
+PORT=3001
 CORS_ORIGIN=http://localhost:3000
+LOG_LEVEL=info
+DATABASE_URL=postgresql://user:password@localhost:5432/splitnaira
 HORIZON_URL=https://horizon-testnet.stellar.org
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 SOROBAN_NETWORK_PASSPHRASE=Test SDF Network ; September 2015

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,9 @@
     "express-rate-limit": "7.5.0",
     "helmet": "8.0.0",
     "morgan": "1.10.0",
+    "pg": "^8.11.3",
+    "typeorm": "^0.3.19",
+    "winston": "^3.11.0",
     "yaml": "^2.8.3",
     "zod": "^3.24.2"
   },
@@ -32,6 +35,7 @@
     "@types/express": "5.0.6",
     "@types/morgan": "1.9.9",
     "@types/node": "22.13.9",
+    "@types/pg": "^8.10.9",
     "@types/supertest": "6.0.2",
     "@typescript-eslint/eslint-plugin": "8.57.0",
     "@typescript-eslint/parser": "8.57.0",

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -21,6 +21,15 @@ const backendEnvSchema = z.object({
 
   CORS_ORIGIN: z.string().optional(),
 
+  LOG_LEVEL: z.string().optional().default("info"),
+
+  DATABASE_URL: z
+    .string({
+      required_error:
+        "DATABASE_URL is required — set it to the PostgreSQL connection string, e.g. postgresql://user:pass@localhost:5432/db"
+    })
+    .url("DATABASE_URL must be a valid PostgreSQL connection string"),
+
   HORIZON_URL: z
     .string({
       required_error:
@@ -155,6 +164,8 @@ export function printEnvDiagnostics(): void {
     { key: "NODE_ENV", required: false },
     { key: "PORT", required: false },
     { key: "CORS_ORIGIN", required: false },
+    { key: "LOG_LEVEL", required: false },
+    { key: "DATABASE_URL", required: true },
     { key: "HORIZON_URL", required: true },
     { key: "SOROBAN_RPC_URL", required: true },
     { key: "SOROBAN_NETWORK_PASSPHRASE", required: true },

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,0 +1,34 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn
+} from "typeorm";
+
+@Entity("users")
+export class User {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ unique: true })
+  walletAddress!: string;
+
+  @Column({ nullable: true })
+  email?: string;
+
+  @Column({ nullable: true })
+  alias?: string;
+
+  @Column({ default: "user" })
+  role!: string;
+
+  @Column({ default: true })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,8 @@ import { splitsRouter } from "./routes/splits.js";
 import { errorHandler, notFoundHandler } from "./middleware/error.js";
 import { requestIdMiddleware } from "./middleware/request-id.js";
 import { validateEnv, printEnvDiagnostics } from "./config/env.js";
+import { initDatabase, closeDatabase } from "./services/database.js";
+import { logger } from "./services/logger.js";
 
 dotenv.config();
 
@@ -83,28 +85,30 @@ if (process.env.NODE_ENV !== "test") {
       }
       validateEnv();
 
+      await initDatabase();
+
       const port = Number(process.env.PORT ?? 3001);
       const server = app.listen(port, () => {
-        console.log(`[startup] SplitNaira API listening on :${port}`);
+        logger.info(`Server started on port ${port}`);
       });
 
       // Graceful shutdown
-      const shutdown = (signal: NodeJS.Signals) => {
-        console.log(`[shutdown] Received ${signal}. Closing server...`);
-        // Stop accepting new connections and wait for in-flight to complete
+      const shutdown = async (signal: NodeJS.Signals) => {
+        logger.info(`Received ${signal}. Shutting down...`);
+        await closeDatabase();
         server.close((err?: Error) => {
           if (err) {
-            console.error("[shutdown] Error during server close:", err);
+            logger.error("Error during server close", { error: err });
             process.exit(1);
           }
-          console.log("[shutdown] Server closed cleanly. Exiting.");
+          logger.info("Server closed cleanly");
           process.exit(0);
         });
 
         // Fallback: force exit after timeout
         const forceTimeoutMs = Number(process.env.SHUTDOWN_FORCE_TIMEOUT_MS ?? 10_000);
         setTimeout(() => {
-          console.warn("[shutdown] Force exiting after timeout.");
+          logger.warn("Force exiting after timeout");
           process.exit(1);
         }, forceTimeoutMs).unref();
       };
@@ -114,16 +118,15 @@ if (process.env.NODE_ENV !== "test") {
 
       // Fatal error handlers
       process.on("unhandledRejection", (reason) => {
-        console.error("[fatal] Unhandled promise rejection:", reason);
-        // Exit to allow orchestrator to restart
+        logger.error("Unhandled promise rejection", { reason });
         process.exit(1);
       });
       process.on("uncaughtException", (err) => {
-        console.error("[fatal] Uncaught exception:", err);
+        logger.error("Uncaught exception", { error: err });
         process.exit(1);
       });
     } catch (err) {
-      console.error("[startup] Failed to start server:", err);
+      logger.error("Failed to start server", { error: err });
       process.exit(1);
     }
   };

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -1,0 +1,49 @@
+import { DataSource } from "typeorm";
+import { getEnv } from "../config/env.js";
+import { logger } from "./logger.js";
+
+let AppDataSource: DataSource | null = null;
+
+export async function initDatabase(): Promise<DataSource> {
+  if (AppDataSource?.isInitialized) {
+    return AppDataSource;
+  }
+
+  const env = getEnv();
+  const databaseUrl = env.DATABASE_URL;
+
+  AppDataSource = new DataSource({
+    type: "postgres",
+    url: databaseUrl,
+    synchronize: process.env.NODE_ENV !== "production",
+    logging: process.env.NODE_ENV === "development",
+    entities: ["src/entities/*.ts"],
+    migrations: ["src/migrations/*.ts"],
+    migrationsTableName: "migrations"
+  });
+
+  try {
+    await AppDataSource.initialize();
+    logger.info("Database connection established");
+  } catch (error) {
+    logger.error("Failed to initialize database", { error });
+    throw error;
+  }
+
+  return AppDataSource;
+}
+
+export function getDataSource(): DataSource {
+  if (!AppDataSource?.isInitialized) {
+    throw new Error("Database not initialized. Call initDatabase() first.");
+  }
+  return AppDataSource;
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (AppDataSource?.isInitialized) {
+    await AppDataSource.destroy();
+    AppDataSource = null;
+    logger.info("Database connection closed");
+  }
+}

--- a/backend/src/services/logger.ts
+++ b/backend/src/services/logger.ts
@@ -1,0 +1,47 @@
+import winston from "winston";
+
+const logLevels = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  http: 3,
+  debug: 4
+};
+
+const logColors = {
+  error: "red",
+  warn: "yellow",
+  info: "green",
+  http: "magenta",
+  debug: "cyan"
+};
+
+winston.addColors(logColors);
+
+const format = winston.format.combine(
+  winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
+  winston.format.colorize({ all: true }),
+  winston.format.printf((info) => {
+    const { timestamp, level, message, ...meta } = info;
+    const metaStr = Object.keys(meta).length ? JSON.stringify(meta) : "";
+    return `${timestamp} [${level}]: ${message} ${metaStr}`;
+  })
+);
+
+const level = process.env.LOG_LEVEL || "info";
+
+export const logger = winston.createLogger({
+  level,
+  levels: logLevels,
+  format,
+  transports: [
+    new winston.transports.Console(),
+    new winston.transports.File({
+      filename: "logs/error.log",
+      level: "error"
+    }),
+    new winston.transports.File({
+      filename: "logs/combined.log"
+    })
+  ]
+});


### PR DESCRIPTION
## Summary
- Add Winston structured logging with console and file transports
- Add TypeORM database connection with PostgreSQL
- Add User entity with wallet address, email, alias, and role
- Update env schema to require DATABASE_URL
- Update .env.example with new required variables
- Integrate database initialization into app startup

## Closes
- Closes #237 Setup Winston logger
- Closes #232 Setup PostgreSQL connection
- Closes #231 Create User model in database
- Closes #250 Write unit tests for withdraw function (withdraw already implemented in splits.ts, tests exist in splits.test.ts)