### PR TITLE
feat: Input component, Dashboard layout, Dependabot config, and Split contract ownership transfer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "contracts"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "ci"

--- a/contracts/events.rs
+++ b/contracts/events.rs
@@ -154,3 +154,26 @@ impl UnallocatedWithdrawn {
         );
     }
 }
+
+/// Emitted when a project's ownership is transferred to a new owner.
+///
+/// Topics:  ["ownership_transferred", project_id]
+/// Data:    (previous_owner address, new_owner address)
+#[derive(Clone, Debug)]
+pub struct OwnershipTransferred {
+    pub project_id: Symbol,
+    pub previous_owner: Address,
+    pub new_owner: Address,
+}
+
+impl OwnershipTransferred {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (
+                Symbol::new(env, "ownership_transferred"),
+                self.project_id.clone(),
+            ),
+            (self.previous_owner.clone(), self.new_owner.clone()),
+        );
+    }
+}

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -7,8 +7,8 @@ use soroban_sdk::{
 mod errors;
 mod events;
 use events::{
-    DepositReceived, DistributionComplete, MetadataUpdated, PaymentSent, ProjectCreated,
-    ProjectLocked, UnallocatedWithdrawn,
+    DepositReceived, DistributionComplete, MetadataUpdated, OwnershipTransferred, PaymentSent,
+    ProjectCreated, ProjectLocked, UnallocatedWithdrawn,
 };
 #[cfg(test)]
 mod tests;
@@ -842,6 +842,50 @@ impl SplitNairaContract {
 
         MetadataUpdated {
             project_id: project_id.clone(),
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    // ----------------------------------------------------------
+    // TRANSFER OWNERSHIP
+    // ----------------------------------------------------------
+
+    /// Transfers ownership of a project to a new address.
+    ///
+    /// Only the current owner can call this. Works on both locked and unlocked
+    /// projects — ownership transfer does not depend on lock state. The new
+    /// owner gains all owner-gated capabilities (update metadata, update
+    /// collaborators on unlocked projects, lock, transfer again).
+    ///
+    /// # Errors
+    /// * `SplitError::NotFound`     - if the project does not exist
+    /// * `SplitError::Unauthorized` - if caller is not the current owner
+    pub fn transfer_project_ownership(
+        env: Env,
+        project_id: Symbol,
+        current_owner: Address,
+        new_owner: Address,
+    ) -> Result<(), SplitError> {
+        let mut project = Self::get_project_or_err(&env, &project_id)?;
+
+        if project.owner != current_owner {
+            return Err(SplitError::Unauthorized);
+        }
+        current_owner.require_auth();
+
+        let previous_owner = project.owner.clone();
+        project.owner = new_owner.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Project(project_id.clone()), &project);
+        Self::bump_project_ttl(&env, &project_id);
+
+        OwnershipTransferred {
+            project_id: project_id.clone(),
+            previous_owner,
+            new_owner,
         }
         .publish(&env);
 

--- a/contracts/tests.rs
+++ b/contracts/tests.rs
@@ -2205,3 +2205,222 @@ fn test_admin_rotation_pause_allowlist_and_recovery_preserve_project_invariants(
     assert_eq!(project.total_distributed, 1_000_0000000i128);
     assert_eq!(client.get_balance(&project_id), 0);
 }
+
+// ============================================================
+//  ISSUE #245 — transfer_project_ownership TESTS
+// ============================================================
+
+#[test]
+fn test_transfer_ownership_success() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+
+    let project_id = Symbol::new(&env, "transfer_ok");
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Transfer OK"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+
+    client.transfer_project_ownership(&project_id, &owner, &new_owner);
+
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.owner, new_owner);
+}
+
+#[test]
+fn test_transfer_ownership_fails_for_non_owner() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+
+    let project_id = Symbol::new(&env, "transfer_unauth");
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Transfer Unauth"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+
+    let result = client.try_transfer_project_ownership(&project_id, &attacker, &new_owner);
+    assert_eq!(result, Err(Ok(SplitError::Unauthorized)));
+
+    // Ownership must be unchanged.
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.owner, owner);
+}
+
+#[test]
+fn test_transfer_ownership_fails_for_missing_project() {
+    let (env, _admin, _token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+
+    let result = client.try_transfer_project_ownership(
+        &Symbol::new(&env, "ghost_project"),
+        &owner,
+        &new_owner,
+    );
+    assert_eq!(result, Err(Ok(SplitError::NotFound)));
+}
+
+#[test]
+fn test_transfer_ownership_works_on_locked_project() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob]),
+        Vec::from_slice(&env, &[7000u32, 3000u32]),
+    );
+
+    let project_id = Symbol::new(&env, "transfer_locked");
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Transfer Locked"),
+        &String::from_str(&env, "film"),
+        &token,
+        &collabs,
+    );
+
+    // Lock the project first.
+    client.lock_project(&project_id, &owner);
+    assert_eq!(client.get_project(&project_id).unwrap().locked, true);
+
+    // Ownership transfer must succeed even for locked projects.
+    client.transfer_project_ownership(&project_id, &owner, &new_owner);
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.owner, new_owner);
+    assert_eq!(project.locked, true);
+}
+
+#[test]
+fn test_new_owner_can_exercise_owner_gated_actions() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+
+    let project_id = Symbol::new(&env, "new_owner_acts");
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "New Owner Acts"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+
+    client.transfer_project_ownership(&project_id, &owner, &new_owner);
+
+    // New owner can update metadata.
+    client.update_project_metadata(
+        &project_id,
+        &new_owner,
+        &String::from_str(&env, "Renamed By New Owner"),
+        &String::from_str(&env, "podcast"),
+    );
+    let project = client.get_project(&project_id).unwrap();
+    assert_eq!(project.title, String::from_str(&env, "Renamed By New Owner"));
+
+    // New owner can update collaborators.
+    let new_collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone(), carol.clone()]),
+        Vec::from_slice(&env, &[4000u32, 3000u32, 3000u32]),
+    );
+    client.update_collaborators(&project_id, &new_owner, &new_collabs);
+    assert_eq!(client.get_project(&project_id).unwrap().collaborators.len(), 3);
+
+    // New owner can lock.
+    client.lock_project(&project_id, &new_owner);
+    assert_eq!(client.get_project(&project_id).unwrap().locked, true);
+
+    // Old owner can no longer perform owner-gated actions.
+    let old_owner_result = client.try_update_project_metadata(
+        &project_id,
+        &owner,
+        &String::from_str(&env, "Old Owner Attempt"),
+        &String::from_str(&env, "art"),
+    );
+    assert_eq!(old_owner_result, Err(Ok(SplitError::Unauthorized)));
+}
+
+#[test]
+fn test_transfer_ownership_emits_event() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice, bob]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+
+    let project_id = Symbol::new(&env, "transfer_evt");
+    client.create_project(
+        &owner,
+        &project_id,
+        &String::from_str(&env, "Transfer Event"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+
+    // Consume events before the transfer so we can check for a new one.
+    let before_count = env.events().all().len();
+    client.transfer_project_ownership(&project_id, &owner, &new_owner);
+    assert!(env.events().all().len() > before_count);
+}

--- a/frontend/src/components/DashboardLayout.tsx
+++ b/frontend/src/components/DashboardLayout.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { clsx } from "clsx";
+
+// ---------------------------------------------------------------------------
+// Nav item definition
+// ---------------------------------------------------------------------------
+
+export interface NavItem {
+  label: string;
+  href: string;
+  icon?: ReactNode;
+}
+
+const DEFAULT_NAV_ITEMS: NavItem[] = [
+  {
+    label: "Projects",
+    href: "/dashboard",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Distribute",
+    href: "/dashboard/distribute",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21L3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+      </svg>
+    ),
+  },
+  {
+    label: "History",
+    href: "/dashboard/history",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
+  },
+  {
+    label: "Settings",
+    href: "/dashboard/settings",
+    icon: (
+      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+      </svg>
+    ),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Sidebar
+// ---------------------------------------------------------------------------
+
+interface SidebarProps {
+  navItems?: NavItem[];
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+function Sidebar({ navItems = DEFAULT_NAV_ITEMS, collapsed, onToggle }: SidebarProps) {
+  const pathname = usePathname();
+
+  return (
+    <aside
+      className={clsx(
+        "flex flex-col h-full bg-gray-900 text-white transition-all duration-200",
+        collapsed ? "w-16" : "w-56",
+      )}
+      aria-label="Sidebar navigation"
+    >
+      {/* Logo / toggle */}
+      <div className="flex items-center justify-between px-3 py-4 border-b border-gray-700">
+        {!collapsed && (
+          <span className="font-display font-bold text-violet-400 text-lg truncate">
+            SplitNaira
+          </span>
+        )}
+        <button
+          onClick={onToggle}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          className="p-1.5 rounded-md hover:bg-gray-700 transition-colors"
+        >
+          <svg className="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            {collapsed ? (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 5l7 7-7 7M5 5l7 7-7 7" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" d="M11 19l-7-7 7-7M19 19l-7-7 7-7" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Nav links */}
+      <nav className="flex-1 overflow-y-auto py-3 space-y-0.5 px-2">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              aria-current={isActive ? "page" : undefined}
+              className={clsx(
+                "flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-violet-600 text-white"
+                  : "text-gray-400 hover:bg-gray-700 hover:text-white",
+                collapsed && "justify-center",
+              )}
+              title={collapsed ? item.label : undefined}
+            >
+              {item.icon && <span className="shrink-0">{item.icon}</span>}
+              {!collapsed && <span className="truncate">{item.label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// DashboardLayout
+// ---------------------------------------------------------------------------
+
+export interface DashboardLayoutProps {
+  children: ReactNode;
+  /** Override the default nav items */
+  navItems?: NavItem[];
+  /** Page-level header content (title, actions, etc.) */
+  header?: ReactNode;
+}
+
+export function DashboardLayout({ children, navItems, header }: DashboardLayoutProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-gray-50">
+      <Sidebar
+        navItems={navItems}
+        collapsed={collapsed}
+        onToggle={() => setCollapsed((c) => !c)}
+      />
+
+      {/* Main content area */}
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+        {/* Top bar */}
+        <header className="flex items-center h-14 border-b border-gray-200 bg-white px-6 shrink-0">
+          {header ?? (
+            <span className="text-sm font-medium text-gray-600">Dashboard</span>
+          )}
+        </header>
+
+        {/* Page content */}
+        <main className="flex-1 overflow-y-auto p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { clsx } from "clsx";
+
+export type InputSize = "sm" | "md" | "lg";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  /** Label rendered above the input */
+  label?: string;
+  /** Error message rendered below the input */
+  error?: string;
+  /** Helper text rendered below the input (shown only when there is no error) */
+  hint?: string;
+  /** Leading icon or adornment rendered inside the input on the left */
+  leading?: React.ReactNode;
+  /** Trailing icon or adornment rendered inside the input on the right */
+  trailing?: React.ReactNode;
+  size?: InputSize;
+  fullWidth?: boolean;
+}
+
+const sizeClasses: Record<InputSize, { wrapper: string; input: string }> = {
+  sm: { wrapper: "h-8", input: "text-sm px-2.5" },
+  md: { wrapper: "h-10", input: "text-sm px-3" },
+  lg: { wrapper: "h-12", input: "text-base px-4" },
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      label,
+      error,
+      hint,
+      leading,
+      trailing,
+      size = "md",
+      fullWidth = false,
+      className,
+      id,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
+    const inputId = id ?? (label ? label.toLowerCase().replace(/\s+/g, "-") : undefined);
+    const hasError = Boolean(error);
+    const { wrapper, input } = sizeClasses[size];
+
+    return (
+      <div className={clsx("flex flex-col gap-1", fullWidth && "w-full")}>
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="text-sm font-medium text-gray-700"
+          >
+            {label}
+          </label>
+        )}
+        <div
+          className={clsx(
+            "relative flex items-center rounded-lg border bg-white transition-colors",
+            wrapper,
+            hasError
+              ? "border-red-400 focus-within:ring-2 focus-within:ring-red-400 focus-within:ring-offset-1"
+              : "border-gray-300 focus-within:ring-2 focus-within:ring-violet-500 focus-within:ring-offset-1",
+            disabled && "bg-gray-50 opacity-60 cursor-not-allowed",
+          )}
+        >
+          {leading && (
+            <span className="pointer-events-none pl-3 text-gray-400">{leading}</span>
+          )}
+          <input
+            ref={ref}
+            id={inputId}
+            disabled={disabled}
+            aria-invalid={hasError}
+            aria-describedby={
+              hasError ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined
+            }
+            className={clsx(
+              "flex-1 bg-transparent outline-none placeholder-gray-400",
+              "disabled:cursor-not-allowed",
+              input,
+              leading && "pl-1.5",
+              trailing && "pr-1.5",
+              className,
+            )}
+            {...props}
+          />
+          {trailing && (
+            <span className="pointer-events-none pr-3 text-gray-400">{trailing}</span>
+          )}
+        </div>
+        {hasError && (
+          <p id={`${inputId}-error`} role="alert" className="text-xs text-red-600">
+            {error}
+          </p>
+        )}
+        {!hasError && hint && (
+          <p id={`${inputId}-hint`} className="text-xs text-gray-500">
+            {hint}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+Input.displayName = "Input";


### PR DESCRIPTION
## Summary

- Adds a reusable, accessible `Input` component with label, error, hint, leading/trailing adornments, and three size variants (`sm`, `md`, `lg`)
- Adds a collapsible `DashboardLayout` with a sidebar, active-route highlighting via `usePathname`, and a configurable nav-item list
- Adds Dependabot configuration for automated weekly dependency updates across npm (frontend), Cargo (contracts), and GitHub Actions
- Adds `transfer_project_ownership` to the Soroban `SplitNairaContract`, allowing owners to hand ownership to a new address on both locked and unlocked projects, with `OwnershipTransferred` event and six tests

## Test plan

- [ ] `Input` component: renders label, displays error state with red ring, renders hint when no error, passes ref, supports all three sizes, forwards HTML input attributes
- [ ] `DashboardLayout`: sidebar collapses and expands with toggle, active nav link is highlighted, `header` slot renders custom content, layout fills viewport
- [ ] Dependabot: `.github/dependabot.yml` present with npm, cargo, and github-actions ecosystems configured for weekly updates
- [ ] Split contract: `cargo test` passes all tests including the six new ownership-transfer tests; `transfer_project_ownership` succeeds for owner, rejects non-owner, rejects missing project, works on locked projects, grants full owner rights to the new address

Closes #209
Closes #213
Closes #254
Closes #245