### PR TITLE
refactor: add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps maintain consistent coding styles across editors.
+# See https://editorconfig.org for more information.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,lock}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.rs]
+indent_size = 4


### PR DESCRIPTION
Closes #264

## Summary
Adds a `.editorconfig` file to the project root to enforce consistent coding styles across all editors and IDEs used by contributors.

## Changes
- Added `.editorconfig` with settings for:
  - UTF-8 charset
  - LF line endings
  - 2-space indentation for most files
  - 4-space indentation for Rust files
  - Final newline insertion
  - Trailing whitespace trimming