### PR TITLE
feat: add frontend production and preview deployment pipeline (Vercel)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,3 +24,39 @@ Next.js app scaffold for the SplitNaira web experience.
 - `src/components` - Reusable UI components
 - `src/lib` - Stellar/Soroban helpers and client utilities
 - `messages` - Translation dictionaries by locale
+
+## Deployment
+
+The frontend is deployed to **Vercel** via GitHub Actions.
+
+| Event | Job | Result |
+|---|---|---|
+| Push to `main` | `deploy-production` | Production deployment |
+| Pull request opened or updated | `deploy-preview` | Preview deployment; URL posted as PR comment |
+| Manual `workflow_dispatch` | `deploy-production` or `deploy-preview` | Controlled by the `environment` input |
+
+All deploy jobs are gated on `verify-frontend` (lint + build + test) passing first.
+
+### Required GitHub Secrets
+
+Three secrets must be configured in the repository before deployments will work:
+
+- `VERCEL_TOKEN` — Vercel personal access token
+- `VERCEL_ORG_ID` — Vercel team or account ID
+- `VERCEL_PROJECT_ID` — Vercel project ID
+
+Run `vercel link` from this directory to generate `.vercel/project.json`, which contains `orgId` and `projectId`.
+
+### Environment Variables
+
+All `NEXT_PUBLIC_*` variables are configured in the Vercel dashboard (Project → Settings → Environment Variables), not in GitHub secrets. They are statically inlined at build time by Next.js.
+
+| Variable | Required | Notes |
+|---|---|---|
+| `NEXT_PUBLIC_STELLAR_NETWORK` | Production | Set to `mainnet` for production; defaults to `testnet` |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Production | Mainnet Soroban RPC URL |
+| `NEXT_PUBLIC_HORIZON_URL` | Production | Mainnet Horizon URL |
+| `NEXT_PUBLIC_API_BASE_URL` | Both | Deployed backend URL — app cannot reach the backend without this |
+| `NEXT_PUBLIC_CONTRACT_ID` | Both | Deployed Soroban contract address |
+
+See [docs/deployment.md](../docs/deployment.md) for the complete setup guide including one-time Vercel project configuration steps.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -5,7 +5,11 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
+  // 'standalone' output is required for Docker-based self-hosting (see frontend/Dockerfile).
+  // Vercel sets VERCEL=1 in its build environment and manages its own output format,
+  // so standalone mode must be disabled there to allow Vercel's native Next.js builder
+  // to produce correctly structured serverless and edge function artifacts.
+  ...(process.env.VERCEL ? {} : { output: 'standalone' }),
   experimental: {
     optimizePackageImports: ["clsx"]
   }


### PR DESCRIPTION
Closes #349

---

## Summary

Implements GitHub Actions-based CI/CD pipeline for frontend deployment using Vercel.

## Changes
- Adds production deployment on merge to `main`
- Adds preview deployments for pull requests
- Adds deployment documentation
- Updates README with deployment instructions
- Adds Vercel compatibility fix for Next.js config
- Adds `.vercel` to `.gitignore`

## Acceptance Criteria
All ACs from issue #349 are fully satisfied (see linked issue).

## Notes for Maintainers
- Requires Vercel project setup (`vercel link`)
- Requires GitHub secrets:
  - VERCEL_TOKEN
  - VERCEL_ORG_ID
  - VERCEL_PROJECT_ID
- Environment variables must be configured in Vercel dashboard

Preview deployments will not work until Vercel project is linked.