### PR TITLE
feat(backend): reliability improvements - Wave 5

### DIFF
--- a/backend/RELIABILITY.md
+++ b/backend/RELIABILITY.md
@@ -1,0 +1,8 @@
+## Reliability Improvements (Wave 5)
+
+### Changes
+- Added `requestTimeout` middleware to return 503 on slow requests
+- Added unit tests for timeout middleware
+
+### Rollback
+Remove `requestTimeout` from `src/index.ts` middleware chain and delete `src/middleware/timeout.ts`.

--- a/backend/src/__tests__/timeout.test.ts
+++ b/backend/src/__tests__/timeout.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { requestTimeout } from "../middleware/timeout";
+import type { Request, Response, NextFunction } from "express";
+
+function makeRes(overrides: Partial<Response> = {}): Response {
+  const listeners: Record<string, (() => void)[]> = {};
+  return {
+    headersSent: false,
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    on: vi.fn((event: string, cb: () => void) => { (listeners[event] ??= []).push(cb); }),
+    emit: (event: string) => listeners[event]?.forEach((cb) => cb()),
+    ...overrides,
+  } as unknown as Response;
+}
+
+describe("requestTimeout middleware", () => {
+  beforeEach(() => vi.useFakeTimers());
+
+  it("calls next immediately", () => {
+    const next = vi.fn() as unknown as NextFunction;
+    const middleware = requestTimeout(1000);
+    middleware({} as Request, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("sends 503 after timeout if headers not sent", () => {
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    requestTimeout(100)({} as Request, res, next);
+    vi.advanceTimersByTime(200);
+    expect(res.status).toHaveBeenCalledWith(503);
+  });
+});

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from "express";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function requestTimeout(ms = DEFAULT_TIMEOUT_MS) {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const timer = setTimeout(() => {
+      if (!res.headersSent) {
+        res.status(503).json({ error: "request_timeout", message: "Request timed out." });
+      }
+    }, ms);
+
+    res.on("finish", () => clearTimeout(timer));
+    res.on("close", () => clearTimeout(timer));
+    next();
+  };
+}


### PR DESCRIPTION
## Implementation Plan
- Added equestTimeout middleware that returns 503 request_timeout after a configurable delay (default 30s)
- Timer is cleared on inish and close events to avoid false positives
- Added unit tests using fake timers

## Testing
- Timeout middleware tests pass via itest run
- Verified 
ext() is called immediately and 503 fires after timeout

## Operational Impact
- Prevents hung requests from holding connections indefinitely
- Safe to add to the Express middleware chain before route handlers

## Rollback
Remove equestTimeout from src/index.ts and delete src/middleware/timeout.ts.

closes #415