### PR TITLE
perf(frontend): add useDebounce hook for input performance

### DIFF
--- a/frontend/src/hooks/useDebounce.test.ts
+++ b/frontend/src/hooks/useDebounce.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value immediately", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("updates the value only after the delay has elapsed", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ val }: { val: string }) => useDebounce(val, 300),
+      { initialProps: { val: "initial" } },
+    );
+    rerender({ val: "updated" });
+    expect(result.current).toBe("initial");
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(result.current).toBe("updated");
+  });
+
+  it("coalesces rapid updates into a single propagation", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ val }: { val: string }) => useDebounce(val, 300),
+      { initialProps: { val: "a" } },
+    );
+    rerender({ val: "b" });
+    rerender({ val: "c" });
+    await act(() => vi.advanceTimersByTimeAsync(300));
+    expect(result.current).toBe("c");
+  });
+});

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Delays updating the returned value until the input has stopped changing for
+ * `delayMs` milliseconds. Useful for cutting redundant re-renders triggered by
+ * fast-changing inputs such as search fields.
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounced(value);
+    }, delayMs);
+
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary
- Add `frontend/src/hooks/useDebounce.ts` — generic debounce hook using `useState` + `useEffect`
- Add `frontend/src/hooks/useDebounce.test.ts` — three vitest cases (immediate return, delayed update, rapid-update coalescing)
- Zero new dependencies; uses React built-ins only

## Implementation Plan
Fast-changing inputs trigger expensive downstream effects on every keystroke. `useDebounce` delays value propagation until the input has been stable for the caller-specified `delayMs`, cutting unnecessary renders.

Closes #409