### PR TITLE
ci: cache Cargo registry to speed up contracts CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32v1-none
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            contracts/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('contracts/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: cargo fmt --all -- --check
       - run: cargo test --locked
       - run: cargo build --release --target wasm32v1-none --locked


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` to the `contracts` job caching `~/.cargo/registry`, `~/.cargo/git`, and `contracts/target`
- Cache key is derived from `Cargo.lock` so it invalidates correctly when dependencies change
- All existing checks (`cargo fmt`, `cargo test`, `cargo build`) are unchanged

## Implementation Plan
The `contracts` CI job currently re-downloads all Rust crates on every run. Caching the Cargo registry under a `Cargo.lock`-keyed key cuts repeated cold-build time and speeds up PR feedback loops.

Closes #412