### PR TITLE
perf(ops): add high-resolution timing utilities for backend observability

### DIFF
--- a/backend/src/__tests__/performance.test.ts
+++ b/backend/src/__tests__/performance.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { startTimer, endTimer, measureAsync } from "../lib/performance.js";
+
+describe("performance utilities", () => {
+  it("returns 0 for an unknown label", () => {
+    expect(endTimer("never-started")).toBe(0);
+  });
+
+  it("returns 0 on second call for the same label", () => {
+    startTimer("once");
+    endTimer("once");
+    expect(endTimer("once")).toBe(0);
+  });
+
+  it("returns a positive elapsed value after a real delay", async () => {
+    startTimer("delay-test");
+    await new Promise((r) => setTimeout(r, 10));
+    const ms = endTimer("delay-test");
+    expect(ms).toBeGreaterThan(0);
+  });
+
+  it("measureAsync resolves with the wrapped function result", async () => {
+    const result = await measureAsync("wrap", () => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+});

--- a/backend/src/lib/performance.ts
+++ b/backend/src/lib/performance.ts
@@ -1,0 +1,24 @@
+const timings = new Map<string, bigint>();
+
+export function startTimer(label: string): void {
+  timings.set(label, process.hrtime.bigint());
+}
+
+export function endTimer(label: string): number {
+  const start = timings.get(label);
+  if (start === undefined) return 0;
+  timings.delete(label);
+  return Number(process.hrtime.bigint() - start) / 1e6;
+}
+
+export async function measureAsync<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  startTimer(label);
+  try {
+    return await fn();
+  } finally {
+    endTimer(label);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `backend/src/lib/performance.ts` — `startTimer`/`endTimer`/`measureAsync` using `process.hrtime.bigint()` for sub-millisecond precision
- Add `backend/src/__tests__/performance.test.ts` — four vitest cases
- Zero new dependencies

## Implementation Plan
Production debugging is hindered by the lack of fine-grained timing. These utilities can be dropped into any route handler to measure hot paths.

Closes #413