### PR TITLE
ci: add job timeout limits and CI/CD compliance runbook - Wave 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   data-integrity:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v6
@@ -23,6 +24,7 @@ jobs:
   frontend:
     needs: data-integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       CI: true
     steps:
@@ -39,6 +41,7 @@ jobs:
   backend:
     needs: data-integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -48,7 +51,7 @@ jobs:
           POSTGRES_DB: splitnaira_ci
         ports:
           - 5432:5432
-        options: >-
+        options: >
           --health-cmd "pg_isready -U splitnaira -d splitnaira_ci"
           --health-interval 10s
           --health-timeout 5s
@@ -80,6 +83,7 @@ jobs:
   contracts:
     needs: data-integrity
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: contracts

--- a/docs/compliance/cicd-wave5.md
+++ b/docs/compliance/cicd-wave5.md
@@ -1,0 +1,31 @@
+# CI/CD Compliance - Wave 5
+
+## Objective
+Deliver production-grade CI/CD compliance improvements for SplitNaira.
+
+## Implementation Plan
+
+### 1. Pipeline Hardening
+- All jobs use pinned action versions (actions/checkout@v4, actions/setup-node@v6)
+- Permissions scoped to minimum required (contents: read)
+- Secrets never echoed in logs
+
+### 2. Build Reproducibility
+- npm ci used instead of npm install for deterministic installs
+- Node version pinned to 20 across all jobs
+- Rust toolchain pinned via dtolnay/rust-toolchain@stable
+
+### 3. Test Gates
+- All PRs must pass: data-integrity, frontend lint+build+test, backend lint+build+test, contracts fmt+test+build
+- continue-on-error not used on required checks
+
+### 4. Deployment Safety
+- Testnet deploy only triggers on main branch push
+- No production deploy without passing CI
+- Rollback: revert commit and push to main triggers redeploy
+
+## Rollback Notes
+CI config changes take effect immediately on next push. Revert this PR to restore previous pipeline.
+
+## Operational Impact
+No changes to application code. Pipeline improvements only.


### PR DESCRIPTION
## Summary
Delivers CI/CD compliance improvements for Wave 5, adding per-job timeout limits to prevent hung pipelines and documenting the CI/CD compliance posture.

## Changes
- Add 	imeout-minutes to all CI jobs (data-integrity: 10m, frontend/backend: 15m, contracts: 20m)
- Add docs/compliance/cicd-wave5.md runbook

## Implementation Plan
See docs/compliance/cicd-wave5.md for full details.

## Rollback Notes
CI config changes take effect immediately. Revert this PR to restore previous pipeline.

## Operational Impact
No changes to application code. Pipeline improvements only.

closes #432