### PR TITLE
feat: load-more pagination for projects list + GitHub deploy templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/deploy-checklist.md
+++ b/.github/ISSUE_TEMPLATE/deploy-checklist.md
@@ -1,0 +1,41 @@
+---
+name: Deploy Checklist
+about: Pre-release checklist for maintainers before approving a deploy
+title: "[Deploy] <version> — pre-release checklist"
+labels: deploy, high priority
+assignees: ''
+---
+
+## Deploy Checklist — SplitNaira
+
+Link the PR this deploy is based on: <!-- #PR_NUMBER -->
+
+### Code Quality
+- [ ] All CI checks pass (lint, type-check, tests)
+- [ ] No `console.log` / debug artifacts in diff
+- [ ] `npm audit` shows no critical/high CVEs in new dependencies
+
+### Contracts
+- [ ] Contract changes audited for re-entrancy and overflow
+- [ ] Migration/upgrade plan documented if contract state changes
+- [ ] Rollback path for contract upgrade is defined
+
+### Database / State
+- [ ] Schema migrations are forward-compatible (no destructive column drops)
+- [ ] Migration tested against a staging DB snapshot
+- [ ] Rollback migration script exists and tested
+
+### Observability
+- [ ] New error paths emit structured logs
+- [ ] Critical flows have success/failure metrics
+- [ ] Runbook updated if on-call response changes
+
+### Release Readiness
+- [ ] `docs/release-readiness-checklist.md` items verified
+- [ ] Changelog entry added
+- [ ] Environment variables for new features documented in `.env.example`
+- [ ] Feature flags set correctly for staged rollout (if applicable)
+
+### Sign-off
+- [ ] Reviewed by at least one maintainer
+- [ ] Approved by `@Split-Naira` org member with deploy access

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+## Summary
+<!-- What does this PR do? Link the issue(s) it closes. -->
+
+Closes #
+
+## Changes
+<!-- Bullet list of significant changes -->
+-
+
+## Testing
+<!-- How was this tested? Unit tests, E2E, manual steps? -->
+- [ ] Unit tests added / updated
+- [ ] Integration / E2E tests pass
+- [ ] Manually verified on local stack
+
+## Deploy Impact
+<!-- Complete this section for any PR that ships to production -->
+
+### Risk level
+- [ ] Low — docs/config only, no logic change
+- [ ] Medium — logic change, backward-compatible
+- [ ] High — breaking change, contract change, or schema migration
+
+### Contract changes
+- [ ] No contract changes
+- [ ] Contract changes included — migration plan: <!-- describe -->
+
+### Database migrations
+- [ ] No migrations
+- [ ] Migration included — rollback script: <!-- path -->
+
+### Environment variables
+- [ ] No new env vars
+- [ ] New env vars added to `.env.example`
+
+### Rollback plan
+<!-- How do we revert if this breaks in production? -->
+
+---
+See [release readiness checklist](../docs/release-readiness-checklist.md) for
+the full pre-deploy gate.

--- a/frontend/src/components/projects/ProjectsList.tsx
+++ b/frontend/src/components/projects/ProjectsList.tsx
@@ -16,6 +16,7 @@ interface ProjectsListProps {
   isLoadingProjectsList: boolean;
   projectsListError: string | null;
   isProjectsListStale: boolean;
+  hasMoreProjects: boolean;
   fetchedProject: SplitProject | null;
   setFetchedProject: (p: SplitProject | null) => void;
   fetchHistory: (id: string, cursor?: string) => Promise<void>;
@@ -41,6 +42,7 @@ export function ProjectsList({
   isLoadingProjectsList,
   projectsListError,
   isProjectsListStale,
+  hasMoreProjects,
   fetchedProject,
   setFetchedProject,
   fetchHistory,
@@ -112,8 +114,36 @@ export function ProjectsList({
               <p className="text-muted text-sm font-medium">
                 {projectsListError
                   ? "Could not load projects. Retry refresh."
-                  : "No projects loaded yet. Click Refresh Projects to load."}
+                  : "No projects found. Click Refresh Projects to load."}
               </p>
+            </div>
+          )}
+
+          {/* Load more — visible when backend signals more pages exist (#380) */}
+          {projectsList.length > 0 && (
+            <div className="flex flex-col items-center gap-3">
+              {hasMoreProjects ? (
+                <button
+                  onClick={() => void onFetchProjectsList(true)}
+                  disabled={isLoadingProjectsList}
+                  className="premium-button rounded-2xl bg-white/5 border border-white/10 px-10 py-4 text-xs font-bold uppercase tracking-widest text-muted hover:text-ink hover:bg-white/10 transition-all disabled:opacity-30"
+                >
+                  {isLoadingProjectsList ? (
+                    <span className="flex items-center gap-2">
+                      <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 12a8 8 0 018-8v8z" />
+                      </svg>
+                      Loading…
+                    </span>
+                  ) : (
+                    "Load More ↓"
+                  )}
+                </button>
+              ) : (
+                <p className="text-[10px] font-bold uppercase tracking-widest text-muted opacity-40">
+                  All projects loaded
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/components/split-app.tsx
+++ b/frontend/src/components/split-app.tsx
@@ -1164,6 +1164,7 @@ export function SplitApp() {
             isLoadingProjectsList={isLoadingProjectsList}
             projectsListError={projectsListError}
             isProjectsListStale={isProjectsListStale}
+            hasMoreProjects={hasMoreProjects}
             fetchedProject={fetchedProject}
             setFetchedProject={setFetchedProject}
             fetchHistory={fetchHistory}


### PR DESCRIPTION
Issue #380 — projects list load more UI:
- Add hasMoreProjects prop to ProjectsList component interface
- Render 'Load More ↓' button below the project grid when hasMoreProjects=true
- Button calls onFetchProjectsList(true) to append next page
- Shows animated spinner while loading; disabled during in-flight requests
- Shows 'All projects loaded' copy once hasMoreProjects=false (last page)
- Wire hasMoreProjects={hasMoreProjects} into split-app.tsx call site (state already managed by onFetchProjectsList via setHasMoreProjects)
- Refresh button resets pagination; empty state copy clarified

Issue #378 — GitHub deploy templates:
- Add .github/ISSUE_TEMPLATE/deploy-checklist.md with pre-deploy gate covering CI, contracts, DB migrations, observability, and sign-off
- Add .github/PULL_REQUEST_TEMPLATE.md with deploy impact section: risk level, contract changes, DB migrations, env vars, rollback plan
- Links to existing docs/release-readiness-checklist.md

Closes #378
Closes #380
Closes #397
Closes #408