### PR TITLE
feat: add self-service claim function for collaborator onboarding (#516)

### DIFF
--- a/contracts/errors.rs
+++ b/contracts/errors.rs
@@ -55,4 +55,7 @@ pub enum SplitError {
 
     /// Withdrawal recipient must not be the contract itself (Wave 5 security hardening)
     InvalidRecipient = 17,
+
+    /// Address is not registered as a collaborator on this project
+    NotACollaborator = 18,
 }

--- a/contracts/events.rs
+++ b/contracts/events.rs
@@ -199,3 +199,23 @@ impl CollaboratorsUpdated {
     }
 }
 
+/// Emitted when a single collaborator self-claims their share via `claim`.
+///
+/// Topics:  ["collaborator_claimed", project_id]
+/// Data:    (claimer address, amount in stroops)
+#[derive(Clone, Debug)]
+pub struct CollaboratorClaimed {
+    pub project_id: Symbol,
+    pub claimer: Address,
+    pub amount: i128,
+}
+
+impl CollaboratorClaimed {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "collaborator_claimed"), self.project_id.clone()),
+            (self.claimer.clone(), self.amount),
+        );
+    }
+}
+

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -11,10 +11,9 @@ const PROJECT_ID_BUCKET_SIZE: u32 = 100;
 mod errors;
 mod events;
 use events::{
-    CollaboratorsUpdated, DepositReceived, DistributionComplete, MetadataUpdated,
-    OwnershipTransferred, PaymentSent, ProjectCreated, ProjectLocked, UnallocatedWithdrawn,
-    DepositReceived, DistributionComplete, MetadataUpdated, OwnershipTransferred, PaymentSent,
-    ProjectCreated, ProjectLocked, UnallocatedWithdrawn, CollaboratorsUpdated,
+    CollaboratorsUpdated, CollaboratorClaimed, DepositReceived, DistributionComplete,
+    MetadataUpdated, OwnershipTransferred, PaymentSent, ProjectCreated, ProjectLocked,
+    UnallocatedWithdrawn,
 };
 #[cfg(test)]
 mod tests;
@@ -616,6 +615,104 @@ impl SplitNairaContract {
         }
 
         Ok(())
+    }
+
+    // ----------------------------------------------------------
+    // SELF-SERVICE CLAIM (User Onboarding — Wave 5)
+    // ----------------------------------------------------------
+
+    /// Allows an individual collaborator to pull their proportional share of
+    /// the current project balance without requiring a full `distribute` call.
+    ///
+    /// This is the pull-based counterpart to the push-based `distribute`.
+    /// It is the primary onboarding path for new collaborators who want to
+    /// claim earnings at their own cadence.
+    ///
+    /// # Behaviour
+    /// - If `claimer` is not a collaborator on the project, returns `NotACollaborator`.
+    /// - If the project balance is zero, returns `Ok(0)` (no error, nothing transferred).
+    /// - Otherwise transfers `floor(balance × basis_points / 10_000)` tokens to
+    ///   `claimer`, reduces `ProjectBalance` by that amount, and updates the
+    ///   per-address `Claimed` ledger entry.
+    /// - Emits a `CollaboratorClaimed` event on every non-zero transfer.
+    ///
+    /// # Errors
+    /// * `SplitError::NotFound`          — project does not exist
+    /// * `SplitError::NotACollaborator`  — claimer is not a collaborator
+    /// * `SplitError::DistributionsPaused` — global pause is active
+    pub fn claim(
+        env: Env,
+        project_id: Symbol,
+        claimer: Address,
+    ) -> Result<i128, SplitError> {
+        claimer.require_auth();
+
+        let paused: bool = env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::DistributionsPaused)
+            .unwrap_or(false);
+        if paused {
+            return Err(SplitError::DistributionsPaused);
+        }
+
+        let project = Self::get_project_or_err(&env, &project_id)?;
+
+        // Locate the claimer in the collaborator list
+        let mut claimer_bps: Option<u32> = None;
+        for collab in project.collaborators.iter() {
+            if collab.address == claimer {
+                claimer_bps = Some(collab.basis_points);
+                break;
+            }
+        }
+        let basis_points = claimer_bps.ok_or(SplitError::NotACollaborator)?;
+
+        let balance: i128 = env
+            .storage()
+            .persistent()
+            .get::<DataKey, i128>(&DataKey::ProjectBalance(project_id.clone()))
+            .unwrap_or(0);
+
+        if balance <= 0 {
+            return Ok(0);
+        }
+
+        let amount = (balance * basis_points as i128) / 10_000;
+        if amount <= 0 {
+            return Ok(0);
+        }
+
+        // Reduce project balance
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProjectBalance(project_id.clone()), &(balance - amount));
+
+        // Update per-address claimed ledger
+        let prev_claimed: i128 = env
+            .storage()
+            .persistent()
+            .get::<DataKey, i128>(&DataKey::Claimed(project_id.clone(), claimer.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(
+            &DataKey::Claimed(project_id.clone(), claimer.clone()),
+            &(prev_claimed + amount),
+        );
+        Self::bump_claimed_ttl(&env, &project_id, &claimer);
+        Self::bump_project_ttl(&env, &project_id);
+
+        // Transfer tokens to claimer
+        let token_client = token::Client::new(&env, &project.token);
+        token_client.transfer(&env.current_contract_address(), &claimer, &amount);
+
+        CollaboratorClaimed {
+            project_id: project_id.clone(),
+            claimer: claimer.clone(),
+            amount,
+        }
+        .publish(&env);
+
+        Ok(amount)
     }
 
     // ----------------------------------------------------------

--- a/contracts/tests.rs
+++ b/contracts/tests.rs
@@ -2757,3 +2757,218 @@ fn test_transfer_ownership_emits_event() {
     client.transfer_project_ownership(&project_id, &owner, &new_owner);
     assert!(env.events().all().len() > before_count);
 }
+
+// ============================================================
+//  CLAIM TESTS (Wave 5 — User Onboarding #516)
+// ============================================================
+
+#[test]
+fn test_claim_transfers_proportional_share() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[6000u32, 4000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_test");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Claim Test"),
+        &String::from_str(&env, "music"),
+        &token, &collabs,
+    );
+
+    let deposit_amount: i128 = 10_000_000;
+    deposit_to_project(&env, &client, &token, &project_id, &owner, deposit_amount);
+
+    let bal_before = token::Client::new(&env, &token).balance(&alice);
+    let claimed = client.claim(&project_id, &alice);
+
+    // Alice has 60% of 10_000_000 = 6_000_000
+    assert_eq!(claimed, 6_000_000, "alice should receive 60% of deposit");
+    let bal_after = token::Client::new(&env, &token).balance(&alice);
+    assert_eq!(bal_after - bal_before, 6_000_000, "alice token balance must increase by claimed amount");
+}
+
+#[test]
+fn test_claim_reduces_project_balance() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_bal");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Balance Test"),
+        &String::from_str(&env, "film"),
+        &token, &collabs,
+    );
+
+    deposit_to_project(&env, &client, &token, &project_id, &owner, 8_000_000);
+
+    client.claim(&project_id, &alice);
+
+    // Remaining balance should be 4_000_000 (bob's half)
+    let remaining = client.get_balance(&project_id).unwrap();
+    assert_eq!(remaining, 4_000_000, "project balance must be reduced by alice's claimed share");
+}
+
+#[test]
+fn test_claim_updates_claimed_ledger() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[7000u32, 3000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_ledger");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Ledger Test"),
+        &String::from_str(&env, "podcast"),
+        &token, &collabs,
+    );
+
+    deposit_to_project(&env, &client, &token, &project_id, &owner, 10_000_000);
+    client.claim(&project_id, &alice);
+
+    let claimed_entry = client.get_claimed(&project_id, &alice);
+    assert_eq!(claimed_entry, 7_000_000, "claimed ledger must reflect alice's total claimed amount");
+}
+
+#[test]
+fn test_claim_returns_zero_when_no_balance() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_zero");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Zero Balance"),
+        &String::from_str(&env, "art"),
+        &token, &collabs,
+    );
+
+    // No deposit — balance is zero
+    let result = client.claim(&project_id, &alice);
+    assert_eq!(result, 0, "claim on empty balance must return 0 without error");
+}
+
+#[test]
+#[should_panic]
+fn test_claim_fails_for_non_collaborator() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let stranger = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_stranger");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Stranger Test"),
+        &String::from_str(&env, "book"),
+        &token, &collabs,
+    );
+
+    deposit_to_project(&env, &client, &token, &project_id, &owner, 1_000_000);
+    // Must panic with NotACollaborator
+    client.claim(&project_id, &stranger);
+}
+
+#[test]
+#[should_panic]
+fn test_claim_fails_when_distributions_paused() {
+    let (env, admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    client.set_admin(&admin);
+    client.pause_distributions(&admin);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_paused");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Paused Test"),
+        &String::from_str(&env, "music"),
+        &token, &collabs,
+    );
+
+    // Must panic with DistributionsPaused
+    client.claim(&project_id, &alice);
+}
+
+#[test]
+fn test_claim_emits_collaborator_claimed_event() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let collabs = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[alice.clone(), bob.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    let project_id = Symbol::new(&env, "claim_event");
+    client.create_project(
+        &owner, &project_id,
+        &String::from_str(&env, "Event Test"),
+        &String::from_str(&env, "music"),
+        &token, &collabs,
+    );
+    deposit_to_project(&env, &client, &token, &project_id, &owner, 2_000_000);
+
+    let events_before = env.events().all().len();
+    client.claim(&project_id, &alice);
+    assert!(
+        env.events().all().len() > events_before,
+        "claim must emit at least one event"
+    );
+}


### PR DESCRIPTION
## Implementation Plan

This PR delivers the **Contracts — User Onboarding** workstream for Wave 5, resolving the gap where collaborators had no pull-based mechanism to claim earnings individually.

### Problem

`distribute()` pushes funds to **all** collaborators at once and is callable by anyone. New collaborators joining a project have no self-service path to claim their earnings at their own cadence — they must wait for a full distribution round. This is a friction point during onboarding and an operational gap for Incident Management.

### Solution: `claim(project_id, claimer)`

A new pull-based `claim` function that lets any registered collaborator sweep their proportional share of the project balance at any time.

---

## Changes

### `contracts/errors.rs`
- Added `NotACollaborator = 18` — returned when the caller is not in the collaborator list

### `contracts/events.rs`
- Added `CollaboratorClaimed` event with topics `["collaborator_claimed", project_id]` and data `(claimer, amount)`

### `contracts/lib.rs`
- Fixed duplicate `use events::{...}` import that was listed twice
- Added `claim(env, project_id, claimer) -> Result<i128, SplitError>`:
  - `claimer.require_auth()` — Soroban auth enforced
  - Checks `DistributionsPaused` guard (consistent with `distribute`)
  - Loads project, finds `claimer` in collaborator list → `NotACollaborator` if absent
  - Transfers `floor(balance × basis_points / 10_000)` tokens to `claimer`
  - Reduces `ProjectBalance` by the claimed amount
  - Updates `Claimed(project_id, claimer)` ledger entry
  - Bumps both project and claimed TTLs
  - Emits `CollaboratorClaimed` event on non-zero transfer
  - Returns `Ok(0)` silently on zero balance (no revert — safe for polling)

### `contracts/tests.rs`
7 new tests covering all acceptance paths:
| Test | What it verifies |
|------|-----------------|
| `claim_transfers_proportional_share` | Alice (60%) receives 60% of deposit |
| `claim_reduces_project_balance` | ProjectBalance decremented by claimed amount |
| `claim_updates_claimed_ledger` | `get_claimed` reflects cumulative claimed |
| `claim_returns_zero_when_no_balance` | Zero balance → `Ok(0)`, no panic |
| `claim_fails_for_non_collaborator` | `NotACollaborator` on unknown address |
| `claim_fails_when_distributions_paused` | `DistributionsPaused` guard respected |
| `claim_emits_collaborator_claimed_event` | At least one event emitted |

---

## Operational Impact & Rollback Notes

- **No storage key changes** — existing `ProjectBalance` and `Claimed` keys are reused; no migration needed
- **No breaking changes** — `distribute` and `batch_distribute` are unchanged
- **Rollback**: revert this commit; no on-chain state is affected until `claim` is called
- **Deploy-safe**: the new function is additive; existing contracts and frontends continue to work unchanged

Closes #516
Closes #518
Closes #504
Closes #521