### PR TITLE
feat(contracts): add CollaboratorClaimed event for Wave 5 self-service claim

### DIFF
--- a/contracts/events.rs
+++ b/contracts/events.rs
@@ -241,3 +241,27 @@ impl DistributionsUnpaused {
     }
 }
 
+
+
+/// Emitted when a collaborator self-service claims their proportional share.
+///
+/// Topics:  ["collaborator_claimed", project_id]
+/// Data:    (claimer address, amount in stroops)
+#[derive(Clone, Debug)]
+pub struct CollaboratorClaimed {
+    pub project_id: Symbol,
+    pub claimer: Address,
+    pub amount: i128,
+}
+
+impl CollaboratorClaimed {
+    pub fn publish(&self, env: &Env) {
+        env.events().publish(
+            (
+                Symbol::new(env, "collaborator_claimed"),
+                self.project_id.clone(),
+            ),
+            (self.claimer.clone(), self.amount),
+        );
+    }
+}


### PR DESCRIPTION
## Implementation Plan

The claim function in lib.rs already emits a CollaboratorClaimed event and imports it from events.rs, but the CollaboratorClaimed struct was missing from events.rs, causing a compile error. This PR adds the missing event definition.

## Changes

### contracts/events.rs
- Added CollaboratorClaimed struct with fields: project_id: Symbol, claimer: Address, mount: i128
- Implemented publish method emitting topic ["collaborator_claimed", project_id] with data (claimer, amount)
- Follows the same pattern as all other events in the file

## Tests
7 existing 	est_claim_* tests in contracts/tests.rs cover the full claim behaviour including:
- successful claim transfers correct amount
- claim returns zero when balance is zero
- non-collaborator claim returns NotACollaborator
- claim respects global pause (DistributionsPaused)
- claim emits CollaboratorClaimed event

All tests pass with cargo test --locked.

## Operational Impact
- No storage schema changes; no migration required
- Fully backward-compatible: existing distribute flow is unchanged
- Rollback: revert this commit; the claim function will fail to compile without the event struct

closes #526