### PR TITLE
feat(backend): add POST /splits/:projectId/claim endpoint for Wave 5 self-service claim

### DIFF
--- a/backend/src/routes/splits.test.ts
+++ b/backend/src/routes/splits.test.ts
@@ -853,3 +853,60 @@ describe("cache stats endpoint", () => {
     expect(Array.isArray(res.body.keys)).toBe(true);
   });
 });
+
+// ============================================================
+// Wave 5: self-service claim endpoint
+// ============================================================
+
+describe("POST /splits/:projectId/claim", () => {
+  const VALID_CLAIMER = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  beforeEach(() => {
+    getAccountMock.mockResolvedValue({ id: VALID_CLAIMER, sequence: "100" });
+    prepareTransactionMock.mockResolvedValue({
+      toXDR: () => "MOCKED_CLAIM_XDR",
+      sequence: "101",
+      fee: "100",
+    });
+  });
+
+  it("returns 200 with xdr when projectId and claimer are valid", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/test_project/claim")
+      .send({ claimer: VALID_CLAIMER })
+      .expect(200);
+
+    expect(res.body).toHaveProperty("xdr");
+  });
+
+  it("returns 400 when claimer is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/test_project/claim")
+      .send({})
+      .expect(400);
+
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  it("returns 400 when claimer is not a valid Stellar address", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/test_project/claim")
+      .send({ claimer: "not-a-stellar-address" })
+      .expect(400);
+
+    expect(res.body.error).toBe("validation_error");
+  });
+
+  it("returns 400 when projectId is invalid", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/splits/!!bad!!/claim")
+      .send({ claimer: VALID_CLAIMER })
+      .expect(400);
+
+    expect(res.body.error).toBe("validation_error");
+  });
+});

--- a/backend/src/routes/splits.ts
+++ b/backend/src/routes/splits.ts
@@ -43,7 +43,8 @@ import {
   pauseDistributionsSchema,
   isTokenAllowedQuerySchema,
   unallocatedQuerySchema,
-  withdrawUnallocatedSchema
+  withdrawUnallocatedSchema,
+  claimSchema
 } from "../schemas/splits.js";
 
 import {
@@ -67,6 +68,7 @@ import {
   buildAllowTokenUnsignedXdr,
   buildDisallowTokenUnsignedXdr,
   buildWithdrawUnallocatedUnsignedXdr,
+  buildClaimUnsignedXdr,
   buildUnsignedContractCall
 } from "../services/splits.service.js";
 
@@ -88,7 +90,8 @@ export {
   pauseDistributionsSchema,
   isTokenAllowedQuerySchema,
   unallocatedQuerySchema,
-  withdrawUnallocatedSchema
+  withdrawUnallocatedSchema,
+  claimSchema
 } from "../schemas/splits.js";
 
 export {
@@ -120,7 +123,8 @@ export {
   buildUnpauseDistributionsUnsignedXdr,
   buildAllowTokenUnsignedXdr,
   buildDisallowTokenUnsignedXdr,
-  buildWithdrawUnallocatedUnsignedXdr
+  buildWithdrawUnallocatedUnsignedXdr,
+  buildClaimUnsignedXdr
 } from "../services/splits.service.js";
 
 function sendValidationError(
@@ -832,6 +836,44 @@ splitsRouter.post("/admin/withdraw-unallocated", async (req: Request, res: Respo
   }
 });
 
+
+// ============================================================
+// Wave 5: self-service claim endpoint
+// ============================================================
+
+splitsRouter.post("/:projectId/claim", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const requestId = res.locals.requestId;
+
+    const parsedParams = projectIdParamSchema.safeParse(req.params.projectId);
+    const parsedBody = claimSchema.safeParse(req.body);
+
+    if (!parsedParams.success || !parsedBody.success) {
+      return sendValidationError(res, requestId, "Invalid request payload.", {
+        params: parsedParams.success ? null : parsedParams.error.flatten(),
+        body: parsedBody.success ? null : parsedBody.error.flatten()
+      });
+    }
+
+    try {
+      const result = await buildClaimUnsignedXdr({
+        projectId: parsedParams.data,
+        claimer: parsedBody.data.claimer
+      });
+      // Evict cached project state; balance will change after submission
+      invalidateCache(`project:${parsedParams.data}`);
+      invalidateCacheByPrefix("list_projects:");
+      return res.status(200).json(result);
+    } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return sendValidationError(res, requestId, error.message);
+      }
+      throw error;
+    }
+  } catch (error) {
+    return next(error);
+  }
+});
 // ============================================================
 // Cache diagnostics (non-sensitive internal endpoint)
 // ============================================================

--- a/backend/src/schemas/splits.ts
+++ b/backend/src/schemas/splits.ts
@@ -191,3 +191,8 @@ export const withdrawUnallocatedSchema = z.object({
     .positive("amount must be greater than 0")
     .describe("amount in stroops to recover")
 });
+
+// Wave 5: self-service claim schema
+export const claimSchema = z.object({
+  claimer: stellarAddressSchema.describe("collaborator address performing the claim")
+});

--- a/backend/src/services/splits.service.ts
+++ b/backend/src/services/splits.service.ts
@@ -624,3 +624,34 @@ export async function buildWithdrawUnallocatedUnsignedXdr(input: WithdrawUnalloc
     }
   };
 }
+
+// ============================================================
+// Wave 5: self-service claim
+// ============================================================
+
+export interface ClaimRequest {
+  projectId: string;
+  claimer: string;
+}
+
+/**
+ * Builds an unsigned XDR transaction for the `claim` contract function.
+ *
+ * The `claim` function is the pull-based counterpart to `distribute`:
+ * a collaborator calls it to withdraw their proportional share of the
+ * current project balance at their own cadence.
+ */
+export async function buildClaimUnsignedXdr(input: ClaimRequest) {
+  const { parseStellarAddress } = await import("./contract-helpers.js");
+  parseStellarAddress(input.claimer, "claimer address");
+
+  return buildUnsignedContractCall({
+    sourceAddress: input.claimer,
+    sourceRoleLabel: "claimer",
+    operation: "claim",
+    args: [
+      nativeToScVal(input.projectId, { type: "symbol" }),
+      Address.fromString(input.claimer).toScVal()
+    ]
+  });
+}


### PR DESCRIPTION
## Implementation Plan

Adds the `POST /splits/:projectId/claim` endpoint that builds an unsigned XDR transaction for the `claim` contract function - the pull-based counterpart to `distribute` introduced in Wave 5.

## Changes

### `backend/src/schemas/splits.ts`
- Added `claimSchema`: validates `claimer` as a valid Stellar address

### `backend/src/services/splits.service.ts`
- Added `ClaimRequest` interface
- Added `buildClaimUnsignedXdr(input: ClaimRequest)`: validates claimer address, then delegates to `buildUnsignedContractCall` with operation `"claim"` and args `[project_id_symbol, claimer_address]`

### `backend/src/routes/splits.ts`
- Imported `claimSchema` and `buildClaimUnsignedXdr`
- Added `POST /:projectId/claim` route: validates params + body, calls `buildClaimUnsignedXdr`, invalidates project and list caches, returns 200 with unsigned XDR
- Re-exported `claimSchema` and `buildClaimUnsignedXdr` for backwards compatibility

### `backend/src/routes/splits.test.ts`
- Added 4 tests: 200 on valid input, 400 on missing claimer, 400 on invalid Stellar address, 400 on invalid projectId

## Operational Impact
- Read-only until the returned XDR is signed and submitted - no state change on the backend
- Cache invalidation is conservative (same pattern as `deposit` and `distribute`)
- Rollback: revert these commits; no DB migrations or schema changes

closes #527