### PR TITLE
fix: add custom scrollbar utility

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -15,7 +15,7 @@
 body {
   margin: 0;
   color: var(--ink);
-  background: 
+  background:
     radial-gradient(1000px at 0% 0%, rgba(212, 154, 42, 0.1), transparent 80%),
     radial-gradient(800px at 100% 100%, rgba(29, 92, 58, 0.1), transparent 80%),
     var(--bg);
@@ -44,6 +44,32 @@ body {
   border-color: var(--green-bright);
   box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.15);
   outline: none;
+}
+
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(52, 211, 153, 0.55) rgba(255, 255, 255, 0.06);
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 999px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, var(--green-bright), var(--green-mid));
+  border: 2px solid rgba(10, 10, 9, 0.92);
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(180deg, var(--green-bright), var(--gold));
 }
 
 .premium-button {


### PR DESCRIPTION
## Summary
- Define the missing `.custom-scrollbar` utility used by the Distribute modal/history lists.
- Add WebKit scrollbar track/thumb styling using the existing dark theme colors.
- Add Firefox `scrollbar-width` and `scrollbar-color` support.

Closes #615

## Validation
- PASS: static CSS assertion for `.custom-scrollbar`, WebKit pseudo-elements, and Firefox scrollbar properties.
- PASS: `npx prettier --check src/app/globals.css`.
- PASS: `git diff --check`.

Additional repo-wide checks currently fail on existing unrelated issues from this checkout:
- `npm run test -- custom-scrollbar.test.ts` is blocked before test execution by the existing React package mismatch: `react@19.2.4` vs `react-dom@19.2.6`.
- `npm run lint` reports existing lint/a11y/type errors across unrelated files.
- `npm run build` compiles, then fails type checking on existing `NEXT_PUBLIC_TX_POLL_TIMEOUT` env typing in `src/lib/soroban-transaction.ts`.