### PR TITLE
docs(contract): document project TTL duration and lifecycle behavior

### DIFF
--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -29,9 +29,22 @@ mod tests;
 
 use errors::SplitError;
 
-// Keep active projects alive by extending persistent TTL whenever they are
-// created, mutated, distributed, or read.
+/// Keep active projects alive by extending persistent TTL whenever they are
+/// created, mutated, distributed, or read.
+/// Active projects survive at least 5 days without a read; any read operation resets this clock.
+///
+/// TODO: If the contract's administrative initialization pattern is extended in the future,
+/// these hard-coded constants should be considered for migration into configurable instance-storage values.
 const PROJECT_TTL_THRESHOLD_LEDGERS: u32 = 50_000;
+
+/// Keep active projects alive by extending persistent TTL whenever they are
+/// created, mutated, distributed, or read.
+/// Active projects survive at least 5 days without a read; any read operation resets this clock.
+///
+/// 100_000 ledgers ≈ 5.8 days at 5s/ledger close time.
+///
+/// TODO: If the contract's administrative initialization pattern is extended in the future,
+/// these hard-coded constants should be considered for migration into configurable instance-storage values.
 const PROJECT_TTL_BUMP_LEDGERS: u32 = 100_000;
 
 // ============================================================


### PR DESCRIPTION
closes #685

## Summary

Resolves #685 by adding clear Rust documentation to the project TTL constants in `contracts/lib.rs`.

The new documentation explains:

* The approximate real-world duration represented by the TTL values (`100,000` ledgers ≈ `5.8 days` assuming a `5s` ledger close time).
* The design intent behind the TTL strategy.
* That active projects remain alive as long as they continue to be accessed, since reads reset the TTL window.
* The future possibility of making these values configurable through contract initialization and instance storage.

## Changes Made

* Added Rust doc comments (`///`) for both TTL constants.
* Added inline comments documenting the approximate duration implied by the ledger values.
* Documented the lifecycle behavior of active projects and TTL refresh semantics.
* Added notes indicating that these hard-coded values may become configurable in future iterations.

## Why

The previous constants lacked context regarding their real-world duration and intended behavior. This change improves maintainability and developer experience by making the TTL strategy explicit in generated documentation.

## Validation

* [x] `cargo doc --no-deps` generates documentation successfully.
* [x] Documentation builds without introducing warnings.
* [x] No functional or behavioral changes were made.

## Notes

This PR is documentation-only and does not modify any contract logic or introduce configurability for TTL values.
