### PR TITLE
feat(backend): request context logging, XSS sanitization, admin audit trail, and OpenAPI docs (#634 #635 #636 #640)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@eslint/js": "9.39.4",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",

--- a/backend/src/__tests__/audit-log.test.ts
+++ b/backend/src/__tests__/audit-log.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+import { AuditLog } from "../entities/AuditLog.js";
+import { clearEnvCache } from "../config/env.js";
+import { markStartupComplete } from "../routes/health.js";
+
+process.env.DATABASE_URL = "https://example.com/postgres";
+process.env.SIMULATOR_ACCOUNT = "GD5T6IPRNCKFOHQ3STZ5BTEYI5V6U5U6U5U6U5U6U5U6U5U6U5U6U5U6";
+process.env.CONTRACT_ID = "CBLASIRZ7CUKC7S5IS3VSNMQGKZ5FTRWLHZZXH7H4YG6ZLRFPJF5H2LR";
+process.env.HORIZON_URL = "https://horizon-testnet.stellar.org";
+process.env.SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org";
+process.env.SOROBAN_NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+const mockAuditSave = vi.fn().mockResolvedValue(undefined);
+const mockAuditCreate = vi.fn((data: unknown) => data);
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Address: {
+    fromString: vi.fn((address: string) => ({
+      toScVal: () => ({ address }),
+      toString: () => address
+    }))
+  },
+  BASE_FEE: "100",
+  Contract: vi.fn().mockImplementation(function (this: unknown) {
+    return { call: vi.fn().mockReturnValue({}) };
+  }),
+  TransactionBuilder: vi.fn().mockImplementation(function (this: unknown) {
+    return {
+      addOperation: vi.fn().mockReturnThis(),
+      setTimeout: vi.fn().mockReturnThis(),
+      build: vi.fn().mockReturnValue({ toXDR: () => "test_xdr" })
+    };
+  }),
+  nativeToScVal: vi.fn((val: unknown) => ({ val })),
+  scValToNative: vi.fn((val: unknown) => val),
+  rpc: {
+    Server: vi.fn().mockImplementation(function (this: unknown) {
+      return {
+        getAccount: vi.fn().mockResolvedValue({
+          accountId: () => "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+          sequenceNumber: () => "1"
+        }),
+        simulateTransaction: vi.fn().mockResolvedValue({ result: { retval: null } }),
+        prepareTransaction: vi.fn().mockResolvedValue({
+          toXDR: () => "test_xdr",
+          sequence: "1",
+          fee: "100"
+        })
+      };
+    })
+  },
+  xdr: {
+    ScVal: {
+      scvU32: vi.fn(),
+      scvVec: vi.fn()
+    }
+  }
+}));
+
+vi.mock("../services/stellar.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/stellar.js")>();
+  return {
+    ...actual,
+    loadStellarConfig: vi.fn(() => ({
+      horizonUrl: "http://horizon",
+      sorobanRpcUrl: "http://rpc",
+      networkPassphrase: "test",
+      contractId: "CBLASIRZ7CUKC7S5IS3VSNMQGKZ5FTRWLHZZXH7H4YG6ZLRFPJF5H2LR",
+      simulatorAccount: "test_account"
+    })),
+    getStellarRpcServer: vi.fn(() => ({
+      getAccount: vi.fn().mockResolvedValue({
+        accountId: () => "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        sequenceNumber: () => "1",
+        incrementSequenceNumber: vi.fn()
+      }),
+      simulateTransaction: vi.fn().mockResolvedValue({ result: { retval: null } }),
+      prepareTransaction: vi.fn().mockResolvedValue({
+        toXDR: () => "test_xdr",
+        sequence: "1",
+        fee: "100"
+      }),
+      getEvents: vi.fn().mockResolvedValue({ events: [] })
+    })),
+    executeWithRetry: vi.fn(async (fn: () => unknown) => fn()),
+    getCached: vi.fn(() => undefined),
+    setCached: vi.fn(),
+    invalidateCache: vi.fn(),
+    invalidateCacheByPrefix: vi.fn(),
+    getCacheStats: vi.fn(() => ({ hits: 0, misses: 0, evictions: 0 })),
+    READ_CACHE_TTL_MS: 30000,
+    checkSorobanReachability: vi.fn().mockResolvedValue({
+      rpc: { ok: true },
+      contract: { ok: true }
+    })
+  };
+});
+
+vi.mock("../services/database.js", () => ({
+  getDataSource: vi.fn(() => ({
+    isInitialized: true,
+    query: vi.fn().mockResolvedValue([{ one: 1 }]),
+    getRepository: vi.fn((entity: unknown) => {
+      if (entity === AuditLog) {
+        return {
+          create: mockAuditCreate,
+          save: mockAuditSave
+        };
+      }
+      return {
+        findOne: vi.fn(),
+        save: vi.fn(),
+        exist: vi.fn().mockResolvedValue(false),
+        create: vi.fn((data: unknown) => data)
+      };
+    })
+  })),
+  initDatabase: vi.fn().mockResolvedValue({}),
+  closeDatabase: vi.fn().mockResolvedValue({})
+}));
+
+const { app } = await import("../index.js");
+
+describe("Admin audit logging", () => {
+  beforeEach(() => {
+    mockAuditSave.mockClear();
+    mockAuditCreate.mockClear();
+    markStartupComplete();
+    process.env.PAYMENTS_ADMIN_API_KEY = "ops-key";
+    process.env.PAYMENTS_ADMIN_WRITE_ENABLED = "true";
+    clearEnvCache();
+  });
+
+  afterEach(() => {
+    delete process.env.PAYMENTS_ADMIN_API_KEY;
+    delete process.env.PAYMENTS_ADMIN_WRITE_ENABLED;
+    clearEnvCache();
+  });
+
+  it("creates an audit log row after a successful pause-distributions call", async () => {
+    const res = await request(app)
+      .post("/splits/admin/pause-distributions")
+      .set("x-admin-api-key", "ops-key")
+      .set("x-request-id", "audit-test-request")
+      .send({
+        admin: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockAuditCreate).toHaveBeenCalledOnce();
+    expect(mockAuditSave).toHaveBeenCalledOnce();
+
+    const auditEntry = mockAuditCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(auditEntry.action).toBe("pause_distributions");
+    expect(auditEntry.requestId).toBe("audit-test-request");
+    expect(auditEntry.ipHash).toBeTruthy();
+    expect(auditEntry.payload).toEqual({
+      admin: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+    });
+  });
+
+  it("does not create an audit log row for failed admin mutations", async () => {
+    const res = await request(app)
+      .post("/splits/admin/pause-distributions")
+      .set("x-admin-api-key", "ops-key")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(mockAuditSave).not.toHaveBeenCalled();
+  });
+
+  it("does not create an audit log row for blocked admin writes", async () => {
+    process.env.PAYMENTS_ADMIN_WRITE_ENABLED = "false";
+    clearEnvCache();
+
+    const res = await request(app)
+      .post("/splits/admin/pause-distributions")
+      .set("x-admin-api-key", "ops-key")
+      .send({
+        admin: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+      });
+
+    expect(res.status).toBe(503);
+    expect(mockAuditSave).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/openapi.test.ts
+++ b/backend/src/__tests__/openapi.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import SwaggerParser from "@apidevtools/swagger-parser";
+import { generateOpenApi } from "../openapi.js";
+
+describe("OpenAPI specification", () => {
+  it("generates a valid OpenAPI document without $ref errors", async () => {
+    const spec = generateOpenApi();
+
+    for (const pathItem of Object.values(spec.paths ?? {})) {
+      for (const operation of Object.values(pathItem ?? {})) {
+        if (operation && typeof operation === "object" && "summary" in operation) {
+          expect(operation.summary).toBeTruthy();
+          expect(String(operation.summary).trim().length).toBeGreaterThan(0);
+        }
+      }
+    }
+
+    await expect(SwaggerParser.validate(spec)).resolves.toBeDefined();
+  });
+});

--- a/backend/src/__tests__/request-context.test.ts
+++ b/backend/src/__tests__/request-context.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import express from "express";
+import request from "supertest";
+import { requestIdMiddleware } from "../middleware/request-id.js";
+import { enrichLogEntry } from "../services/logger.js";
+import { getRequestId, requestContext } from "../services/request-context.js";
+
+describe("Request context propagation", () => {
+  it("propagates requestId through AsyncLocalStorage during HTTP handling", async () => {
+    const observed: string[] = [];
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.get("/test", (_req, res) => {
+      observed.push(getRequestId() ?? "");
+      enrichLogEntry({ level: "info", message: "nested service call" });
+      observed.push(String(getRequestId()));
+      res.json({ ok: true });
+    });
+
+    await request(app)
+      .get("/test")
+      .set("x-request-id", "integration-trace-id")
+      .expect(200);
+
+    expect(observed).toEqual(["integration-trace-id", "integration-trace-id"]);
+  });
+
+  it("automatically enriches log entries with requestId from context", () => {
+    requestContext.run({ requestId: "log-correlation-id" }, () => {
+      const entry = enrichLogEntry({ level: "info", message: "service log" });
+      expect(entry.requestId).toBe("log-correlation-id");
+    });
+  });
+
+  it("does not overwrite an explicitly provided requestId on log entries", () => {
+    requestContext.run({ requestId: "context-id" }, () => {
+      const entry = enrichLogEntry({
+        level: "info",
+        message: "explicit",
+        requestId: "explicit-id"
+      });
+      expect(entry.requestId).toBe("explicit-id");
+    });
+  });
+
+  it("generates a requestId when none is provided", async () => {
+    let observedId: string | undefined;
+    const app = express();
+    app.use(requestIdMiddleware);
+    app.get("/test", (_req, res) => {
+      observedId = getRequestId();
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get("/test").expect(200);
+
+    expect(observedId).toBeTruthy();
+    expect(res.headers["x-request-id"]).toBe(observedId);
+  });
+});

--- a/backend/src/__tests__/security-xss.test.ts
+++ b/backend/src/__tests__/security-xss.test.ts
@@ -4,16 +4,30 @@
  * Related to: GitHub Issue #292 - XSS in Split Description Field
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createSplitSchema,
   updateMetadataSchema,
   collaboratorSchema,
 } from "../schemas/splits.js";
+import { sanitizeString } from "../lib/sanitize.js";
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  Address: {
+    fromString: vi.fn(() => ({})),
+  },
+}));
 
 describe("Security: XSS Prevention", () => {
+  describe("Server-side sanitization", () => {
+    it("sanitizeString strips HTML tags and trims whitespace", () => {
+      expect(sanitizeString("  <script>alert(1)</script>  ")).toBe("alert(1)");
+      expect(sanitizeString("<b>Hello</b> World")).toBe("Hello World");
+    });
+  });
+
   describe("Title field validation", () => {
-    it("should reject script tags in title", () => {
+    it("should strip script tags from title and store sanitized text", () => {
       const maliciousTitle = "<script>alert('XSS')</script>";
       const result = createSplitSchema.safeParse({
         owner: "GBRPYHIL2CI3WHPSKYNYFRM5MH72RTZGKSW2ZSOB2BBZKJFMV7NZUKX",
@@ -34,11 +48,9 @@ describe("Security: XSS Prevention", () => {
           },
         ],
       });
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues.some((i) => i.path.includes("title"))).toBe(
-          true
-        );
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.title).toBe("alert('XSS')");
       }
     });
 
@@ -160,6 +172,32 @@ describe("Security: XSS Prevention", () => {
         ],
       });
       expect(result.success).toBe(true);
+    });
+
+    it("should strip HTML script tags from title via server-side sanitization", () => {
+      const result = createSplitSchema.safeParse({
+        owner: "GBRPYHIL2CI3WHPSKYNYFRM5MH72RTZGKSW2ZSOB2BBZKJFMV7NZUKX",
+        projectId: "test_project",
+        title: "<script>alert(1)</script>",
+        projectType: "music",
+        token: "GBRPYHIL2CI3WHPSKYNYFRM5MH72RTZGKSW2ZSOB2BBZKJFMV7NZUKX",
+        collaborators: [
+          {
+            address: "GBRPYHIL2CI3WHPSKYNYFRM5MH72RTZGKSW2ZSOB2BBZKJFMV7NZUKX",
+            alias: "Collaborator 1",
+            basisPoints: 5000,
+          },
+          {
+            address: "GC4T3X2BFXDFJZ7TZHQ2U4BLQZFNV3KVEYAQN37HQNGXZKAHXCN5KFS7",
+            alias: "Collaborator 2",
+            basisPoints: 5000,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.title).toBe("alert(1)");
+      }
     });
   });
 

--- a/backend/src/entities/AuditLog.ts
+++ b/backend/src/entities/AuditLog.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index
+} from "typeorm";
+
+@Entity("audit_log")
+export class AuditLog {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", length: 128 })
+  @Index()
+  action!: string;
+
+  @CreateDateColumn({ name: "performed_at", type: "timestamptz" })
+  performedAt!: Date;
+
+  @Column({ name: "ip_hash", type: "varchar", length: 16 })
+  ipHash!: string;
+
+  @Column({ name: "request_id", type: "varchar", length: 64 })
+  requestId!: string;
+
+  @Column({ type: "jsonb", nullable: true })
+  payload!: Record<string, unknown> | null;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import {
   enforcePaymentsAdminWriteEnabled,
   requirePaymentsAdminAccess
 } from "./middleware/payments-admin.js";
+import { auditAdminMutationsMiddleware } from "./middleware/audit-log.js";
 import { eventsRouter } from "./routes/events.js";
 import { validateEnv, printEnvDiagnostics } from "./config/env.js";
 import { initDatabase, closeDatabase } from "./services/database.js";
@@ -95,7 +96,8 @@ app.use(
   "/splits/admin",
   adminLimiter,
   requirePaymentsAdminAccess,
-  enforcePaymentsAdminWriteEnabled
+  enforcePaymentsAdminWriteEnabled,
+  auditAdminMutationsMiddleware
 );
 app.use("/splits", (req, res, next) => {
   if (req.method === "GET") return readLimiter(req, res, next);

--- a/backend/src/lib/sanitize.ts
+++ b/backend/src/lib/sanitize.ts
@@ -1,0 +1,6 @@
+/**
+ * Strips HTML tags and trims whitespace from user-provided text fields.
+ */
+export function sanitizeString(input: string): string {
+  return input.replace(/<[^>]*>/g, "").trim();
+}

--- a/backend/src/middleware/audit-log.ts
+++ b/backend/src/middleware/audit-log.ts
@@ -1,0 +1,64 @@
+import type { NextFunction, Request, Response } from "express";
+import { getDataSource } from "../services/database.js";
+import { AuditLog } from "../entities/AuditLog.js";
+import { hashIp } from "./payments-admin.js";
+import { logger } from "../services/logger.js";
+
+const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+function deriveAction(req: Request): string {
+  const path = req.path.replace(/^\/+/, "");
+  const segments = path.split("/").filter(Boolean);
+  const resource = segments[segments.length - 1] ?? "unknown";
+  return resource.replace(/-/g, "_");
+}
+
+function buildPayload(req: Request): Record<string, unknown> | null {
+  const body = req.body;
+  if (body === undefined || body === null) {
+    return null;
+  }
+  if (typeof body === "object" && !Array.isArray(body)) {
+    return body as Record<string, unknown>;
+  }
+  return { value: body };
+}
+
+async function persistAuditLog(req: Request, res: Response): Promise<void> {
+  try {
+    const dataSource = getDataSource();
+    const repository = dataSource.getRepository(AuditLog);
+    const entry = repository.create({
+      action: deriveAction(req),
+      ipHash: hashIp(req.ip),
+      requestId: String(res.locals.requestId ?? ""),
+      payload: buildPayload(req)
+    });
+    await repository.save(entry);
+  } catch (error) {
+    logger.error("Failed to persist admin audit log", { error, path: req.originalUrl });
+  }
+}
+
+/**
+ * Records an audit log row after each successful admin mutation under /splits/admin.
+ * Failed or rejected requests are not logged.
+ */
+export function auditAdminMutationsMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (!MUTATION_METHODS.has(req.method)) {
+    next();
+    return;
+  }
+
+  res.on("finish", () => {
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      void persistAuditLog(req, res);
+    }
+  });
+
+  next();
+}

--- a/backend/src/middleware/payments-admin.ts
+++ b/backend/src/middleware/payments-admin.ts
@@ -5,7 +5,7 @@ import { logger } from "../services/logger.js";
 
 export const PAYMENTS_ADMIN_API_KEY_HEADER = "x-admin-api-key";
 
-function hashIp(ip: string | undefined): string {
+export function hashIp(ip: string | undefined): string {
   if (!ip) return "unknown";
   return createHash("sha256").update(ip).digest("hex").slice(0, 16);
 }
@@ -26,7 +26,6 @@ function logBlockedAdminRequest(req: Request, res: Response, reason: string): vo
     reason,
     method: req.method,
     path: req.originalUrl,
-    requestId: res.locals.requestId,
     ip: hashIp(req.ip)
   });
 }

--- a/backend/src/middleware/request-id.ts
+++ b/backend/src/middleware/request-id.ts
@@ -1,11 +1,13 @@
 import type { RequestHandler } from "express";
 import { randomUUID } from "crypto";
+import { requestContext } from "../services/request-context.js";
 
 /**
  * Generates (or propagates) a request correlation id.
  * - Accepts inbound `x-request-id` or `x-correlation-id`
  * - Always sets `res.locals.requestId`
  * - Mirrors both headers in the response for cross-service tracing
+ * - Stores requestId in AsyncLocalStorage for automatic logger correlation
  */
 export const requestIdMiddleware: RequestHandler = (req, res, next) => {
   const incoming =
@@ -15,6 +17,9 @@ export const requestIdMiddleware: RequestHandler = (req, res, next) => {
   res.locals.requestId = requestId;
   res.setHeader("x-request-id", requestId);
   res.setHeader("x-correlation-id", requestId);
-  next();
+
+  requestContext.run({ requestId }, () => {
+    next();
+  });
 };
 

--- a/backend/src/migrations/1760000000003-AddAuditLog.ts
+++ b/backend/src/migrations/1760000000003-AddAuditLog.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddAuditLog1760000000003 implements MigrationInterface {
+  name = "AddAuditLog1760000000003";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "audit_log" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "action" character varying(128) NOT NULL,
+        "performed_at" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "ip_hash" character varying(16) NOT NULL,
+        "request_id" character varying(64) NOT NULL,
+        "payload" jsonb,
+        CONSTRAINT "PK_audit_log" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`CREATE INDEX "IDX_audit_log_action" ON "audit_log" ("action")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_audit_log_action"`);
+    await queryRunner.query(`DROP TABLE "audit_log"`);
+  }
+}

--- a/backend/src/openapi.ts
+++ b/backend/src/openapi.ts
@@ -23,9 +23,66 @@ import {
   historyQuerySchema,
   projectIdParamSchema,
   stellarAddressSchema,
+  allowlistQuerySchema,
+  adminTokenSchema,
+  pauseDistributionsSchema,
+  isTokenAllowedQuerySchema,
+  unallocatedQuerySchema,
+  withdrawUnallocatedSchema,
+  claimSchema,
 } from "./routes/splits.js";
+import {
+  userRegistrationSchema,
+  userResponseSchema,
+} from "./schemas/user.schemas.js";
+import {
+  transactionHistoryQuerySchema,
+  transactionRecordSchema,
+  transactionHistoryResponseSchema,
+} from "./schemas/transactions.schemas.js";
 
 const registry = new OpenAPIRegistry();
+
+const ApiErrorSchema = registry.register(
+  "ApiError",
+  z.object({
+    error: z.string().describe("Machine-readable error code"),
+    message: z.string().optional().describe("Human-readable error message"),
+    requestId: z.string().optional().describe("Request correlation ID"),
+    details: z.record(z.string(), z.unknown()).optional().describe("Additional error context"),
+  })
+);
+
+function apiErrorResponse(description: string) {
+  return {
+    description,
+    content: {
+      "application/json": {
+        schema: ApiErrorSchema,
+      },
+    },
+  };
+}
+
+function standardErrorResponses(options: {
+  badRequest?: boolean;
+  unauthorized?: boolean;
+  notFound?: boolean;
+  conflict?: boolean;
+  serverError?: boolean;
+  badGateway?: boolean;
+  unavailable?: boolean;
+} = {}) {
+  const responses: Record<number, ReturnType<typeof apiErrorResponse>> = {};
+  if (options.badRequest) responses[400] = apiErrorResponse("Validation error");
+  if (options.unauthorized) responses[401] = apiErrorResponse("Authentication required");
+  if (options.notFound) responses[404] = apiErrorResponse("Resource not found");
+  if (options.conflict) responses[409] = apiErrorResponse("Conflict with existing resource");
+  if (options.serverError) responses[500] = apiErrorResponse("Internal server error");
+  if (options.badGateway) responses[502] = apiErrorResponse("Upstream RPC or contract error");
+  if (options.unavailable) responses[503] = apiErrorResponse("Service temporarily unavailable");
+  return responses;
+}
 
 // ─── Components ───────────────────────────────────────────────────────────────
 
@@ -76,6 +133,7 @@ registry.registerPath({
   method: "get",
   path: "/splits",
   summary: "List all split projects",
+  description: "Returns a paginated list of on-chain split projects with optional search and type filters.",
   tags: ["Splits"],
   request: {
     query: listProjectsSchema,
@@ -89,6 +147,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -96,6 +155,7 @@ registry.registerPath({
   method: "post",
   path: "/splits",
   summary: "Create a new split project",
+  description: "Builds an unsigned Soroban transaction XDR to create a new revenue-split project on-chain.",
   tags: ["Splits"],
   request: {
     body: {
@@ -115,6 +175,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -122,6 +183,7 @@ registry.registerPath({
   method: "get",
   path: "/splits/{projectId}",
   summary: "Get project details by ID",
+  description: "Fetches the current on-chain state for a single split project including collaborators and balances.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -135,7 +197,7 @@ registry.registerPath({
         },
       },
     },
-    404: { description: "Project not found" },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -143,6 +205,7 @@ registry.registerPath({
   method: "post",
   path: "/splits/{projectId}/lock",
   summary: "Lock a project permanently",
+  description: "Builds an unsigned XDR to permanently lock a project, preventing further metadata or collaborator changes.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -163,6 +226,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -170,6 +234,7 @@ registry.registerPath({
   method: "post",
   path: "/splits/{projectId}/deposit",
   summary: "Deposit funds into a project",
+  description: "Builds an unsigned XDR to deposit tokens into a split project's escrow balance.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -190,6 +255,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -197,6 +263,7 @@ registry.registerPath({
   method: "patch",
   path: "/splits/{projectId}/metadata",
   summary: "Update project metadata (title/category)",
+  description: "Builds an unsigned XDR to update a project's title and project type. Text fields are server-side sanitized.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -217,6 +284,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -224,6 +292,7 @@ registry.registerPath({
   method: "put",
   path: "/splits/{projectId}/collaborators",
   summary: "Update project collaborators",
+  description: "Builds an unsigned XDR to replace the collaborator list and revenue share allocations.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -244,6 +313,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -251,6 +321,7 @@ registry.registerPath({
   method: "post",
   path: "/splits/{projectId}/distribute",
   summary: "Distribute project funds to collaborators",
+  description: "Builds an unsigned XDR to distribute accumulated project funds according to collaborator shares.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -271,6 +342,7 @@ registry.registerPath({
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -289,6 +361,7 @@ registry.registerPath({
   method: "get",
   path: "/splits/{projectId}/claimable/{collaborator}",
   summary: "Get claimable payout information for a collaborator",
+  description: "Returns the claimable, claimed, and total allocated amounts for a collaborator on a project.",
   tags: ["Splits"],
   request: {
     params: z.object({
@@ -305,9 +378,36 @@ registry.registerPath({
         },
       },
     },
-    400: { description: "Validation error — invalid projectId or collaborator address" },
-    404: { description: "Project not found or collaborator has no claimable info" },
-    500: { description: "Contract or server failure" },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/{projectId}/claim",
+  summary: "Claim collaborator payout",
+  description: "Builds an unsigned XDR allowing a collaborator to claim their allocated share from a project.",
+  tags: ["Splits"],
+  request: {
+    params: z.object({ projectId: projectIdParamSchema }),
+    body: {
+      content: {
+        "application/json": {
+          schema: claimSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Unsigned transaction XDR",
+      content: {
+        "application/json": {
+          schema: XdrResponseSchema,
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -315,6 +415,7 @@ registry.registerPath({
   method: "get",
   path: "/splits/{projectId}/history",
   summary: "Get project transaction history",
+  description: "Returns paginated on-chain distribution and payment events for a project.",
   tags: ["Splits"],
   request: {
     params: z.object({ projectId: projectIdParamSchema }),
@@ -327,10 +428,391 @@ registry.registerPath({
         "application/json": {
           schema: z.object({
             items: z.array(z.any()),
+            nextCursor: z.string().nullable(),
           }),
         },
       },
     },
+    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+  },
+});
+
+// ─── Admin Endpoints ──────────────────────────────────────────────────────────
+
+const AdminStatusSchema = registry.register(
+  "AdminStatus",
+  z.object({
+    admin: z.string().nullable(),
+    isPaused: z.boolean(),
+  })
+);
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/allowlist",
+  summary: "List allowed payment tokens",
+  description: "Returns the contract admin address, total allowed token count, and a paginated token allowlist.",
+  tags: ["Admin"],
+  request: { query: allowlistQuerySchema },
+  responses: {
+    200: {
+      description: "Token allowlist page",
+      content: {
+        "application/json": {
+          schema: z.object({
+            admin: z.string().nullable(),
+            count: z.number().int(),
+            tokens: z.array(z.string()),
+          }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/admin/allow-token",
+  summary: "Allow a payment token",
+  description: "Builds an unsigned XDR to add a token to the contract allowlist. Requires admin API key.",
+  tags: ["Admin"],
+  request: {
+    body: { content: { "application/json": { schema: adminTokenSchema } } },
+  },
+  responses: {
+    200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/admin/disallow-token",
+  summary: "Disallow a payment token",
+  description: "Builds an unsigned XDR to remove a token from the contract allowlist. Requires admin API key.",
+  tags: ["Admin"],
+  request: {
+    body: { content: { "application/json": { schema: adminTokenSchema } } },
+  },
+  responses: {
+    200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/admin/pause-distributions",
+  summary: "Pause all distributions",
+  description: "Builds an unsigned XDR to pause contract-wide fund distributions. Requires admin API key.",
+  tags: ["Admin"],
+  request: {
+    body: { content: { "application/json": { schema: pauseDistributionsSchema } } },
+  },
+  responses: {
+    200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/admin/unpause-distributions",
+  summary: "Unpause distributions",
+  description: "Builds an unsigned XDR to resume contract-wide fund distributions. Requires admin API key.",
+  tags: ["Admin"],
+  request: {
+    body: { content: { "application/json": { schema: pauseDistributionsSchema } } },
+  },
+  responses: {
+    200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/status",
+  summary: "Get admin contract status",
+  description: "Returns the current contract admin address and whether distributions are paused.",
+  tags: ["Admin"],
+  responses: {
+    200: {
+      description: "Admin status",
+      content: { "application/json": { schema: AdminStatusSchema } },
+    },
+    ...standardErrorResponses({ unauthorized: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/is-token-allowed",
+  summary: "Check if a token is allowed",
+  description: "Returns whether a specific token contract address is on the allowlist.",
+  tags: ["Admin"],
+  request: { query: isTokenAllowedQuerySchema },
+  responses: {
+    200: {
+      description: "Token allowlist check result",
+      content: {
+        "application/json": {
+          schema: z.object({ token: z.string(), isAllowed: z.boolean() }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/token-count",
+  summary: "Get allowed token count",
+  description: "Returns the total number of tokens on the contract allowlist.",
+  tags: ["Admin"],
+  responses: {
+    200: {
+      description: "Allowed token count",
+      content: {
+        "application/json": {
+          schema: z.object({ count: z.number().int() }),
+        },
+      },
+    },
+    ...standardErrorResponses({ unauthorized: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/unallocated",
+  summary: "Get unallocated token balance",
+  description: "Returns the unallocated balance held by the contract for a given token.",
+  tags: ["Admin"],
+  request: { query: unallocatedQuerySchema },
+  responses: {
+    200: {
+      description: "Unallocated balance",
+      content: {
+        "application/json": {
+          schema: z.object({ token: z.string(), unallocated: z.string() }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/splits/admin/withdraw-unallocated",
+  summary: "Withdraw unallocated tokens",
+  description: "Builds an unsigned XDR to recover unallocated token balance from the contract. Requires admin API key.",
+  tags: ["Admin"],
+  request: {
+    body: { content: { "application/json": { schema: withdrawUnallocatedSchema } } },
+  },
+  responses: {
+    200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/splits/admin/cache-stats",
+  summary: "Get read cache statistics",
+  description: "Returns internal read-cache hit/miss statistics for diagnostics.",
+  tags: ["Admin"],
+  responses: {
+    200: {
+      description: "Cache statistics",
+      content: {
+        "application/json": {
+          schema: z.object({
+            hits: z.number().int(),
+            misses: z.number().int(),
+            evictions: z.number().int(),
+            ttlMs: z.number().int(),
+          }),
+        },
+      },
+    },
+    ...standardErrorResponses({ unauthorized: true, serverError: true }),
+  },
+});
+
+// ─── User Endpoints ───────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "post",
+  path: "/users/register",
+  summary: "Register a new user",
+  description: "Creates a user profile linked to a Stellar wallet address.",
+  tags: ["Users"],
+  request: {
+    body: { content: { "application/json": { schema: userRegistrationSchema } } },
+  },
+  responses: {
+    201: {
+      description: "Registered user profile",
+      content: { "application/json": { schema: userResponseSchema } },
+    },
+    ...standardErrorResponses({ badRequest: true, conflict: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/users/login",
+  summary: "Log in by wallet address",
+  description: "Authenticates a registered user and returns a JWT bearer token.",
+  tags: ["Users"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({ walletAddress: stellarAddressSchema }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Authenticated user with JWT",
+      content: {
+        "application/json": {
+          schema: userResponseSchema.extend({ token: z.string() }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, notFound: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/users/me",
+  summary: "Get authenticated user profile",
+  description: "Returns the profile of the user identified by the JWT bearer token.",
+  tags: ["Users"],
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "Authenticated user profile",
+      content: { "application/json": { schema: userResponseSchema } },
+    },
+    ...standardErrorResponses({ unauthorized: true, notFound: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "patch",
+  path: "/users/me",
+  summary: "Update authenticated user profile",
+  description: "Updates email or alias for the authenticated user.",
+  tags: ["Users"],
+  security: [{ bearerAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z.object({
+            email: z.string().email().optional(),
+            alias: z.string().min(1).max(64).optional(),
+          }),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Updated user profile",
+      content: { "application/json": { schema: userResponseSchema } },
+    },
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, notFound: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/users/{walletAddress}",
+  summary: "Get user by wallet address",
+  description: "Looks up a public user profile by Stellar wallet address.",
+  tags: ["Users"],
+  request: {
+    params: z.object({ walletAddress: stellarAddressSchema }),
+  },
+  responses: {
+    200: {
+      description: "User profile",
+      content: { "application/json": { schema: userResponseSchema } },
+    },
+    ...standardErrorResponses({ badRequest: true, notFound: true, serverError: true }),
+  },
+});
+
+// ─── Transaction Endpoints ────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/transactions/history",
+  summary: "Query payout transaction history",
+  description: "Returns paginated payout records with optional wallet, date, and status filters.",
+  tags: ["Transactions"],
+  request: { query: transactionHistoryQuerySchema },
+  responses: {
+    200: {
+      description: "Paginated transaction history",
+      content: { "application/json": { schema: transactionHistoryResponseSchema } },
+    },
+    ...standardErrorResponses({ badRequest: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/transactions/{txHash}",
+  summary: "Get transaction by hash",
+  description: "Returns a single payout record matching the Stellar transaction hash.",
+  tags: ["Transactions"],
+  request: {
+    params: z.object({ txHash: z.string().min(1) }),
+  },
+  responses: {
+    200: {
+      description: "Transaction record",
+      content: { "application/json": { schema: transactionRecordSchema } },
+    },
+    ...standardErrorResponses({ badRequest: true, notFound: true, serverError: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/transactions/recipient/{walletAddress}",
+  summary: "List transactions for a recipient",
+  description: "Returns all payout records sent to the given Stellar wallet address.",
+  tags: ["Transactions"],
+  request: {
+    params: z.object({ walletAddress: z.string().regex(/^G[A-Z2-7]{55}$/) }),
+  },
+  responses: {
+    200: {
+      description: "Recipient transaction list",
+      content: {
+        "application/json": {
+          schema: z.object({
+            transactions: z.array(transactionRecordSchema),
+            total: z.number().int(),
+            walletAddress: z.string(),
+          }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true, serverError: true }),
   },
 });
 
@@ -528,6 +1010,22 @@ export function generateOpenApi() {
       description: "Premium royalty management API on Stellar network.",
     },
     servers: [{ url: "http://localhost:3001" }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT",
+          description: "JWT obtained from POST /users/login",
+        },
+        adminApiKey: {
+          type: "apiKey",
+          in: "header",
+          name: "x-admin-api-key",
+          description: "Payments admin API key for /splits/admin mutation endpoints",
+        },
+      },
+    },
   });
 }
 

--- a/backend/src/routes/splits.ts
+++ b/backend/src/routes/splits.ts
@@ -158,6 +158,13 @@ const ctrl = new SplitsController();
 
 splitsRouter.get("/", ctrl.listProjects.bind(ctrl));
 splitsRouter.get("/:projectId", ctrl.getProject.bind(ctrl));
+/**
+ * @openapi
+ * POST /splits/{projectId}/lock
+ * summary: Lock a project permanently
+ * description: Builds an unsigned XDR to permanently lock a project against further changes.
+ * tags: [Splits]
+ */
 splitsRouter.post("/:projectId/lock", ctrl.lockProject.bind(ctrl));
 splitsRouter.post("/:projectId/deposit", ctrl.deposit.bind(ctrl));
 
@@ -168,7 +175,6 @@ function logPaymentsAdminAction(
 ) {
   logger.info("Payments admin action prepared", {
     action,
-    requestId: res.locals.requestId,
     ...details
   });
 }
@@ -194,6 +200,13 @@ splitsRouter.get("/", async (req: Request, res: Response, next: NextFunction) =>
   }
 });
 
+/**
+ * @openapi
+ * GET /splits/{projectId}
+ * summary: Get project details by ID
+ * description: Fetches the current on-chain state for a single split project.
+ * tags: [Splits]
+ */
 splitsRouter.get("/:projectId", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const parsedId = projectIdParamSchema.safeParse(req.params.projectId);
@@ -598,6 +611,13 @@ splitsRouter.post("/admin/disallow-token", async (req: Request, res: Response, n
   }
 });
 
+/**
+ * @openapi
+ * POST /splits/admin/pause-distributions
+ * summary: Pause all distributions
+ * description: Builds an unsigned XDR to pause contract-wide fund distributions. Requires admin API key.
+ * tags: [Admin]
+ */
 splitsRouter.post("/admin/pause-distributions", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const requestId = res.locals.requestId;

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -10,14 +10,14 @@ export const transactionsRouter = Router();
 const payoutHistoryService = createPayoutHistoryService();
 
 /**
+ * @openapi
  * GET /transactions/history
- * Fetch transaction history with optional filters
+ * summary: Query payout transaction history
+ * description: Returns paginated payout records with optional wallet, date, and status filters.
+ * tags: [Transactions]
  */
 transactionsRouter.get("/history", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const requestId = res.locals.requestId;
-
-    // Validate query parameters
     const parsed = transactionHistoryQuerySchema.safeParse(req.query);
     if (!parsed.success) {
       throw new AppError(
@@ -38,7 +38,6 @@ transactionsRouter.get("/history", async (req: Request, res: Response, next: Nex
       status,
       limit,
       offset,
-      requestId
     });
 
     const { records, total } = await payoutHistoryService.getPayoutsWithCount({
@@ -62,12 +61,14 @@ transactionsRouter.get("/history", async (req: Request, res: Response, next: Nex
 });
 
 /**
- * GET /transactions/:txHash
- * Get a specific transaction by transaction hash
+ * @openapi
+ * GET /transactions/{txHash}
+ * summary: Get transaction by hash
+ * description: Returns a single payout record matching the Stellar transaction hash.
+ * tags: [Transactions]
  */
 transactionsRouter.get("/:txHash", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const requestId = res.locals.requestId;
     const txHashParam = req.params.txHash;
     const txHash = Array.isArray(txHashParam) ? txHashParam[0] : txHashParam;
 
@@ -79,7 +80,7 @@ transactionsRouter.get("/:txHash", async (req: Request, res: Response, next: Nex
       );
     }
 
-    logger.info("Fetching transaction by hash", { txHash, requestId });
+    logger.info("Fetching transaction by hash", { txHash });
 
     // Search for the transaction by hash
     const results = await payoutHistoryService.searchPayouts(txHash);
@@ -100,12 +101,14 @@ transactionsRouter.get("/:txHash", async (req: Request, res: Response, next: Nex
 });
 
 /**
- * GET /transactions/recipient/:walletAddress
- * Get all transactions for a specific recipient
+ * @openapi
+ * GET /transactions/recipient/{walletAddress}
+ * summary: List transactions for a recipient
+ * description: Returns all payout records sent to the given Stellar wallet address.
+ * tags: [Transactions]
  */
 transactionsRouter.get("/recipient/:walletAddress", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const requestId = res.locals.requestId;
     const { walletAddress } = req.params;
 
     // Validate wallet address format
@@ -122,7 +125,7 @@ transactionsRouter.get("/recipient/:walletAddress", async (req: Request, res: Re
       );
     }
 
-    logger.info("Fetching transactions for recipient", { walletAddress, requestId });
+    logger.info("Fetching transactions for recipient", { walletAddress });
 
     const recipient = parsed.data;
     if (!recipient) {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -11,14 +11,14 @@ import { authJwtMiddleware } from "../middleware/auth-jwt.js";
 export const usersRouter = Router();
 
 /**
+ * @openapi
  * POST /users/register
- * Register a new user with wallet address
- * Transaction-safe: Automatically rolled back on error
+ * summary: Register a new user
+ * description: Creates a user profile linked to a Stellar wallet address.
+ * tags: [Users]
  */
 usersRouter.post("/register", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const requestId = res.locals.requestId;
-
     const { walletAddress, email, alias } = userRegistrationSchema.parse(req.body);
 
     // Get repository without opening a transaction
@@ -55,7 +55,6 @@ usersRouter.post("/register", async (req: Request, res: Response, next: NextFunc
     logger.info("User registered successfully", {
       userId: savedUser.id,
       walletAddress: savedUser.walletAddress,
-      requestId,
     });
 
     return res.status(201).json({
@@ -74,13 +73,14 @@ usersRouter.post("/register", async (req: Request, res: Response, next: NextFunc
 });
 
 /**
+ * @openapi
  * POST /users/login
- * Log in a user by wallet address
+ * summary: Log in by wallet address
+ * description: Authenticates a registered user and returns a JWT bearer token.
+ * tags: [Users]
  */
 usersRouter.post("/login", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const requestId = res.locals.requestId;
-
     const loginSchema = z.object({
       walletAddress: stellarAddressSchema
     });
@@ -104,7 +104,6 @@ usersRouter.post("/login", async (req: Request, res: Response, next: NextFunctio
     logger.info("User logged in successfully", {
       userId: user.id,
       walletAddress: user.walletAddress,
-      requestId
     });
 
     return res.status(200).json({
@@ -124,8 +123,11 @@ usersRouter.post("/login", async (req: Request, res: Response, next: NextFunctio
 });
 
 /**
+ * @openapi
  * GET /users/me
- * Get the authenticated user's profile
+ * summary: Get authenticated user profile
+ * description: Returns the profile of the user identified by the JWT bearer token.
+ * tags: [Users]
  */
 usersRouter.get("/me", authJwtMiddleware, async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -151,8 +153,11 @@ usersRouter.get("/me", authJwtMiddleware, async (req: Request, res: Response, ne
 });
 
 /**
+ * @openapi
  * PATCH /users/me
- * Update the authenticated user's profile
+ * summary: Update authenticated user profile
+ * description: Updates email or alias for the authenticated user.
+ * tags: [Users]
  */
 usersRouter.patch("/me", authJwtMiddleware, async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -192,8 +197,11 @@ usersRouter.patch("/me", authJwtMiddleware, async (req: Request, res: Response, 
 });
 
 /**
- * GET /users/:walletAddress
- * Get user by wallet address
+ * @openapi
+ * GET /users/{walletAddress}
+ * summary: Get user by wallet address
+ * description: Looks up a public user profile by Stellar wallet address.
+ * tags: [Users]
  */
 usersRouter.get("/:walletAddress", async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/backend/src/schemas/splits.ts
+++ b/backend/src/schemas/splits.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { CollaboratorSchema } from "../generated/contract-types.js";
 import { Address } from "@stellar/stellar-sdk";
+import { sanitizeString } from "../lib/sanitize.js";
 
 // Security: Safe text validator - prevents XSS by restricting to safe character ranges
 // Allows: alphanumeric, spaces, hyphens, underscores, periods, commas, ampersands
@@ -38,6 +39,17 @@ export const safeTextField = z
   .string()
   .refine(validateSafeText, "contains unsafe characters or patterns");
 
+const sanitizedSafeTextField = (constraints: z.ZodString) =>
+  z.string().transform(sanitizeString).pipe(constraints);
+
+const titleField = sanitizedSafeTextField(
+  safeTextField.min(1, "title is required").max(128, "title must be at most 128 characters")
+);
+
+const projectTypeField = sanitizedSafeTextField(
+  safeTextField.min(1, "projectType is required").max(32, "projectType must be at most 32 characters")
+);
+
 export const collaboratorSchema = CollaboratorSchema.omit({ basis_points: true }).extend({
   address: stellarAddressSchema,
   alias: safeTextField.min(1, "alias is required").max(100, "alias must be at most 100 characters"),
@@ -56,8 +68,8 @@ export const createSplitSchema = z
       .min(1, "projectId is required")
       .max(32)
       .regex(/^[a-zA-Z0-9_]+$/, "projectId must be alphanumeric/underscore"),
-    title: safeTextField.min(1, "title is required").max(128, "title must be at most 128 characters"),
-    projectType: safeTextField.min(1, "projectType is required").max(32, "projectType must be at most 32 characters"),
+    title: titleField,
+    projectType: projectTypeField,
     token: stellarAddressSchema.describe("token"),
     collaborators: z.array(collaboratorSchema).min(2, "at least 2 collaborators are required")
   })
@@ -108,8 +120,8 @@ export const depositSchema = z.object({
 
 export const updateMetadataSchema = z.object({
   owner: stellarAddressSchema.describe("owner"),
-  title: safeTextField.min(1, "title is required").max(128, "title must be at most 128 characters"),
-  projectType: safeTextField.min(1, "projectType is required").max(32, "projectType must be at most 32 characters")
+  title: titleField,
+  projectType: projectTypeField
 });
 
 export const updateCollaboratorsSchema = z

--- a/backend/src/services/EventListenerService.ts
+++ b/backend/src/services/EventListenerService.ts
@@ -147,24 +147,7 @@ export async function pollEvents() {
                 status: "completed"
               });
             }
-          } catch (err) {
-            logger.warn(
-              `Could not resolve token address for project ${projectId}. Using fallback.`,
-              { err }
-            );
           }
-
-          records.push(
-            repo.create({
-              roundId: projectId,
-              recipient,
-              amount,
-              token,
-              timestamp,
-              txHash,
-              status: "completed",
-            })
-          );
         } catch (eventError) {
           logger.error("Error processing polled Soroban event", {
             event,

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -3,6 +3,7 @@ import { DataSource, type QueryRunner } from "typeorm";
 import { getEnv } from "../config/env.js";
 import { User } from "../entities/User.js";
 import { TransactionRecord } from "../entities/Transaction.js";
+import { AuditLog } from "../entities/AuditLog.js";
 import { logger } from "./logger.js";
 
 let AppDataSource: DataSource | null = null;
@@ -45,7 +46,7 @@ export function createDataSource(): DataSource {
     url: databaseUrl,
     synchronize: false,
     logging: process.env.NODE_ENV === "development",
-    entities: [User, TransactionRecord],
+    entities: [User, TransactionRecord, AuditLog],
     migrations: ["src/migrations/*.ts"],
     migrationsTableName: "migrations",
     extra: {

--- a/backend/src/services/logger.ts
+++ b/backend/src/services/logger.ts
@@ -1,4 +1,5 @@
 import winston from "winston";
+import { getRequestId } from "./request-context.js";
 
 const logLevels = {
   error: 0,
@@ -61,8 +62,21 @@ const scrubFormat = winston.format((info) => {
   return info;
 });
 
+export function enrichLogEntry(
+  info: winston.Logform.TransformableInfo
+): winston.Logform.TransformableInfo {
+  const requestId = getRequestId();
+  if (requestId && info.requestId === undefined) {
+    info.requestId = requestId;
+  }
+  return info;
+}
+
+const requestContextFormat = winston.format((info) => enrichLogEntry(info));
+
 const prettyFormat = winston.format.combine(
   winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
+  requestContextFormat(),
   scrubFormat(),
   winston.format.colorize({ all: true }),
   winston.format.printf((info) => {
@@ -74,6 +88,7 @@ const prettyFormat = winston.format.combine(
 
 const jsonFormat = winston.format.combine(
   winston.format.timestamp(),
+  requestContextFormat(),
   scrubFormat(),
   winston.format.json()
 );

--- a/backend/src/services/request-context.ts
+++ b/backend/src/services/request-context.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface RequestContextStore {
+  requestId: string;
+}
+
+export const requestContext = new AsyncLocalStorage<RequestContextStore>();
+
+export function getRequestId(): string | undefined {
+  return requestContext.getStore()?.requestId;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "zod": "^4.3.6"
             },
             "devDependencies": {
+                "@apidevtools/swagger-parser": "^12.1.0",
                 "@eslint/js": "9.39.4",
                 "@types/cors": "2.8.19",
                 "@types/express": "5.0.6",
@@ -401,6 +402,97 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@apidevtools/json-schema-ref-parser": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+            "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15",
+                "js-yaml": "^4.1.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/philsturgeon"
+            }
+        },
+        "node_modules/@apidevtools/openapi-schemas": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+            "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@apidevtools/swagger-methods": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+            "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@apidevtools/swagger-parser": {
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+            "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apidevtools/json-schema-ref-parser": "14.0.1",
+                "@apidevtools/openapi-schemas": "^2.1.0",
+                "@apidevtools/swagger-methods": "^3.0.2",
+                "ajv": "^8.17.1",
+                "ajv-draft-04": "^1.0.0",
+                "call-me-maybe": "^1.0.2"
+            },
+            "peerDependencies": {
+                "openapi-types": ">=7"
+            }
+        },
+        "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@asamuzakjp/css-color": {
             "version": "5.1.11",
@@ -9049,6 +9141,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/call-me-maybe": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+            "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -10852,6 +10951,23 @@
             "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
             "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -13684,6 +13800,14 @@
             "dependencies": {
                 "fn.name": "1.x.x"
             }
+        },
+        "node_modules/openapi-types": {
+            "version": "12.1.3",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+            "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/openapi3-ts": {
             "version": "4.5.0",


### PR DESCRIPTION
## Summary

This PR implements four backend improvements for observability, security, compliance, and API documentation:

- **#634 — Request-scoped logging:** Introduces `AsyncLocalStorage` request context so `requestId` is automatically attached to every log line during an HTTP request lifecycle, without handlers manually passing it.
- **#635 — Server-side XSS sanitization:** Adds `sanitizeString()` and applies it as a Zod transform on `title` and `projectType` in split schemas before existing safe-text validation.
- **#636 — Admin audit trail:** Creates an `audit_log` table and middleware that records successful `/splits/admin` mutations (action, hashed IP, requestId, payload).
- **#640 — OpenAPI documentation:** Documents all splits, users, transactions, and admin routes with summaries, descriptions, error responses, and swagger-parser validation.

Also fixes a pre-existing syntax error in `EventListenerService.ts` that blocked test app imports.

Closes #634
Closes #635
Closes #636
Closes #640

## Test plan

- [x] `npm test -- src/__tests__/request-context.test.ts` — AsyncLocalStorage + logger enrichment
- [x] `npm test -- src/__tests__/security-xss.test.ts` — HTML tag stripping and XSS rejection
- [x] `npm test -- src/__tests__/audit-log.test.ts` — audit row on successful pause-distributions; no row on 400/503
- [x] `npm test -- src/__tests__/openapi.test.ts` — non-empty summaries; `SwaggerParser.validate()` passes
- [ ] Run migration before deploy: `npm run migration:run`
- [ ] Verify Swagger UI at `/api/docs` shows populated summaries for all documented routes


Made with [Cursor](https://cursor.com)