### PR TITLE
fix(frontend): prevent stale-closure guard from blocking Projects reload (#612)

### DIFF
--- a/frontend/src/components/projects/ProjectsList.tsx
+++ b/frontend/src/components/projects/ProjectsList.tsx
@@ -66,11 +66,27 @@ export function ProjectsList({
           <div className="glass-card rounded-[2.5rem] p-8 md:p-10">
             <h2 className="font-display text-2xl tracking-tight mb-2">Available Projects</h2>
             <button
-              onClick={() => void onFetchProjectsList()}
+              type="button"
+              onClick={() => void onFetchProjectsList(false)}
               disabled={isLoadingProjectsList}
-              className="premium-button rounded-2xl bg-greenMid px-8 py-4 text-xs font-bold uppercase tracking-widest text-white disabled:opacity-20"
+              aria-label="Refresh projects"
+              title="Refresh projects"
+              className="premium-button inline-flex items-center gap-2 rounded-2xl bg-greenMid px-8 py-4 text-xs font-bold uppercase tracking-widest text-white disabled:opacity-20"
             >
-              Refresh Projects
+              <svg
+                aria-hidden="true"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className={clsx("h-4 w-4", isLoadingProjectsList && "animate-spin")}
+              >
+                <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+                <path d="M21 3v6h-6" />
+              </svg>
+              {isLoadingProjectsList ? "Refreshing…" : "Refresh Projects"}
             </button>
             {projectsListError && (
               <div className="mt-4 rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3">

--- a/frontend/src/components/split-app.tsx
+++ b/frontend/src/components/split-app.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars, react-hooks/exhaustive-deps, @typescript-eslint/no-explicit-any, no-empty */
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any, no-empty */
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
@@ -158,7 +158,10 @@ export function SplitApp() {
   const depositModalRef = useRef<HTMLDivElement | null>(null);
 
   const [projectsList, setProjectsList] = useState<SplitProject[]>([]);
-  const [projectsListLoaded, setProjectsListLoaded] = useState(false);
+  // Tracks whether the Projects tab has performed its initial load. A ref (not
+  // state) so re-visiting the tab does not re-trigger the auto-load effect,
+  // while still distinguishing first load from a re-visit.
+  const projectsLoadedRef = useRef(false);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [isLoadingProjectsList, setIsLoadingProjectsList] = useState(false);
   const [projectsStart, setProjectsStart] = useState(0);
@@ -778,8 +781,12 @@ export function SplitApp() {
 
   // Phase 3: Fetch projects list from backend with pagination
   const onFetchProjectsList = useCallback(async (loadMore = false) => {
+    // Only guard against concurrent fetches. The previous
+    // `if (!loadMore && projectsList.length > 0) return;` guard silently
+    // swallowed forced reloads (e.g. the Refresh button, or returning to the
+    // tab after creating a project elsewhere) — a non-loadMore call must
+    // always be allowed to refetch fresh contract state.
     if (isLoadingProjectsList) return;
-    if (!loadMore && projectsList.length > 0) return;
 
     setIsLoadingProjectsList(true);
     setProjectsListError(null);
@@ -805,9 +812,11 @@ export function SplitApp() {
       setProjectsListError("Failed to fetch projects list.");
     } finally {
       setIsLoadingProjectsList(false);
-      setProjectsListLoaded(true);
+      projectsLoadedRef.current = true;
     }
-  }, [isLoadingProjectsList, projectsList.length, projectsStart, listProjects]);
+    // `listProjects` is a stable module-level import (not state), so it is
+    // intentionally excluded from the dependency array.
+  }, [isLoadingProjectsList, projectsStart]);
 
   const onFetchDashboardData = useCallback(async () => {
     setIsLoadingDashboard(true);
@@ -941,8 +950,11 @@ export function SplitApp() {
 
   useEffect(() => {
     if (activeTab === "projects") {
-      if (projectsList.length === 0 && !isLoadingProjectsList) {
-        void onFetchProjectsList();
+      // Fetch fresh data on the first visit to the Projects tab. Subsequent
+      // re-visits don't auto-refetch (use the Refresh button); the ref keeps
+      // this decision independent of the current list length.
+      if (!projectsLoadedRef.current && !isLoadingProjectsList) {
+        void onFetchProjectsList(false);
       }
     } else if (activeTab === "dashboard" && dashboardData.length === 0 && !isLoadingDashboard) {
       void onFetchDashboardData();
@@ -954,7 +966,6 @@ export function SplitApp() {
     isLoadingProjectsList,
     onFetchDashboardData,
     onFetchProjectsList,
-    projectsList.length,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #612 

onFetchProjectsList carried a `if (!loadMore && projectsList.length > 0) return;` guard that silently swallowed forced reloads — the Refresh button became a no-op once the list was non-empty, and returning to the Projects tab after creating a project elsewhere never refetched fresh contract state. The callback also listed `listProjects` (a stable module import) as a dependency, tripping react-hooks/exhaustive-deps.

split-app.tsx:
- Drop the length guard; keep only the concurrent-fetch guard, so any non-loadMore call always refetches
- Remove `listProjects` (and the now-unused `projectsList.length`) from the useCallback deps; deps are now exhaustive-correct
- Replace the dead `projectsListLoaded` state with a `projectsLoadedRef` and gate the first-load effect on it, so the initial visit always loads and re-visits don't auto-refetch (Refresh handles that)
- Remove the now-unused `react-hooks/exhaustive-deps` from the file-level eslint-disable (the other disabled rules are retained)

ProjectsList.tsx:
- Make the header Refresh button an explicit icon button calling onFetchProjectsList(false), with a spinner + "Refreshing…" while loading

Verified: `npm run lint -w frontend` passes (max-warnings=0); no new test failures vs main (the 17 failing tests pre-exist on main, unrelated). The new logic is type-clean.
