### PR TITLE
feat(frontend): explorer link via explicit props on TransactionReceiptView (#614)

### DIFF
--- a/frontend/src/components/TransactionReceiptView.tsx
+++ b/frontend/src/components/TransactionReceiptView.tsx
@@ -109,17 +109,27 @@ const EXTERNAL_LINK_ICON = (
 export function TransactionReceiptView({
   receipt,
   network,
+  explorerUrl,
+  explorerLabel,
   onRetry
 }: {
   receipt: TransactionReceipt;
   network: string | null;
+  /** Explorer URL for this transaction. When omitted, it is derived from
+   * `getExplorerUrl(receipt.hash, network)` so existing callers keep working. */
+  explorerUrl?: string;
+  /** Explorer label. When omitted, derived from `getExplorerLabel(network)`. */
+  explorerLabel?: string;
   /** Called when the user clicks "Refresh to Retry" on a timeout.
    * Defaults to a full page reload if not provided, preserving the
    * original behavior for existing call sites. */
   onRetry?: () => void;
 }) {
-  const explorerUrl = getExplorerUrl(receipt.hash, network);
-  const explorerLabel = getExplorerLabel(network);
+  // Prefer explicitly provided explorer props (keeps this component purely
+  // presentational); fall back to deriving them from the network for callers
+  // that only pass `network`.
+  const resolvedExplorerUrl = explorerUrl ?? getExplorerUrl(receipt.hash, network);
+  const resolvedExplorerLabel = explorerLabel ?? getExplorerLabel(network);
   const actionCopy = ACTION_COPY[receipt.action];
 
   const isConfirming = receipt.lifecycle === "confirming";
@@ -234,24 +244,24 @@ export function TransactionReceiptView({
             <p className="font-mono text-[9px] text-muted break-all opacity-60">Tx: {receipt.hash}</p>
             {(isSuccess || isConfirming || isTimeout) && (
               <a
-                href={explorerUrl}
+                href={resolvedExplorerUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 text-[10px] font-bold text-greenBright underline underline-offset-4 hover:text-white transition-colors"
               >
-                Verify on {explorerLabel}
+                Verify on {resolvedExplorerLabel}
                 <span className="sr-only"> (opens in a new tab)</span>
                 {EXTERNAL_LINK_ICON}
               </a>
             )}
             {isFailed && (
               <a
-                href={explorerUrl}
+                href={resolvedExplorerUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 text-[10px] font-bold text-red-300/90 underline underline-offset-4 hover:text-white transition-colors"
               >
-                Inspect on {explorerLabel}
+                Inspect on {resolvedExplorerLabel}
                 <span className="sr-only"> (opens in a new tab)</span>
                 {EXTERNAL_LINK_ICON}
               </a>

--- a/frontend/src/components/create/CreateSplitWizard.tsx
+++ b/frontend/src/components/create/CreateSplitWizard.tsx
@@ -3,6 +3,7 @@
 import { Controller, type Control, type UseFormRegister, type FieldErrors, type FieldArrayWithId } from "react-hook-form";
 import { clsx } from "clsx";
 import { StrKey } from "@stellar/stellar-sdk";
+import { getExplorerUrl, getExplorerLabel } from "@/lib/stellar";
 import type { SplitProject } from "@/lib/stellar";
 import type { WalletState } from "@/lib/wallet";
 import { TokenSelector } from "../TypeSelector";
@@ -327,7 +328,12 @@ export function CreateSplitWizard({
         </button>
       </div>
       {receipt && receipt.action === "create" && (
-        <TransactionReceiptView receipt={receipt} network={wallet.network ?? null} />
+        <TransactionReceiptView
+          receipt={receipt}
+          network={wallet.network ?? null}
+          explorerUrl={getExplorerUrl(receipt.hash, wallet.network ?? null)}
+          explorerLabel={getExplorerLabel(wallet.network ?? null)}
+        />
       )}
 
       {latestTxHash && (

--- a/frontend/src/components/manage/ManageSplitView.tsx
+++ b/frontend/src/components/manage/ManageSplitView.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from "clsx";
 import { sanitizeText } from "@/lib/security";
+import { getExplorerLabel } from "@/lib/stellar";
 import type { SplitProject } from "@/lib/stellar";
 import type { ProjectHistoryItem, AdminStatusState } from "@/lib/api";
 import type { WalletState } from "@/lib/wallet";
@@ -321,7 +322,12 @@ export function ManageSplitView({
                 </p>
               )}
               {receipt && (receipt.action === "distribute" || receipt.action === "lock" || receipt.action === "deposit") && (
-                <TransactionReceiptView receipt={receipt} network={wallet.network ?? null} />
+                <TransactionReceiptView
+                  receipt={receipt}
+                  network={wallet.network ?? null}
+                  explorerUrl={getExplorerUrl(receipt.hash, wallet.network ?? null)}
+                  explorerLabel={getExplorerLabel(wallet.network ?? null)}
+                />
               )}
             </div>
           </div>

--- a/frontend/src/components/projects/ProjectsList.tsx
+++ b/frontend/src/components/projects/ProjectsList.tsx
@@ -330,7 +330,12 @@ export function ProjectsList({
                   </p>
                 )}
                 {receipt && (receipt.action === "distribute" || receipt.action === "lock" || receipt.action === "deposit") && (
-                  <TransactionReceiptView receipt={receipt} network={wallet.network ?? null} />
+                  <TransactionReceiptView
+                    receipt={receipt}
+                    network={wallet.network ?? null}
+                    explorerUrl={getExplorerUrl(receipt.hash, wallet.network ?? null)}
+                    explorerLabel={getExplorerLabel(wallet.network ?? null)}
+                  />
                 )}
               </div>
             </div>


### PR DESCRIPTION
closes #614 

TransactionReceiptView is documented as a "pure presentational component" but imported `getExplorerUrl`/`getExplorerLabel` and derived the explorer link itself. This adds the explicit prop contract from the issue and threads it from the real render sites, keeping the component presentational — while remaining fully backward compatible.

TransactionReceiptView.tsx:
- Add optional `explorerUrl?` / `explorerLabel?` props
- Resolve to the props when provided, else fall back to getExplorerUrl(receipt.hash, network) / getExplorerLabel(network) so callers that only pass `network` are unaffected
- Render the existing success/confirming/timeout/failed explorer links from the resolved values

Call sites (ProjectsList, ManageSplitView, CreateSplitWizard) now pass explorerUrl={getExplorerUrl(receipt.hash, wallet.network)} and explorerLabel={getExplorerLabel(wallet.network)} (split-app renders the receipt indirectly through these three components, not directly).

Verified: `npm run lint -w frontend` passes (max-warnings=0); no new test failures vs main; touched files type-clean.
### Database migrations
- [ ] No migrations
- [ ] Migration included — rollback script: <!-- path -->

### Environment variables
- [ ] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
<!-- How do we revert if this breaks in production? -->

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.
