### PR TITLE
feat(frontend): define animate-slide-in toast animation (#617)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -91,3 +91,48 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+/* Toast entrance animation (used by toast-provider.tsx via `animate-slide-in`).
+   Animates only `transform` and `opacity` — both GPU-compositable — so the
+   slide stays smooth on mobile. */
+@keyframes slide-in {
+  from {
+    transform: translateX(110%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slide-out {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateX(110%);
+    opacity: 0;
+  }
+}
+
+.animate-slide-in {
+  animation: slide-in 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  will-change: transform, opacity;
+}
+
+/* Optional helper for an exit transition. Dismiss currently removes the toast
+   immediately; apply this class before unmount if a slide-out is desired. */
+.animate-slide-out {
+  animation: slide-out 0.2s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  will-change: transform, opacity;
+}
+
+/* Respect reduced-motion preferences: show/hide without the slide. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-in,
+  .animate-slide-out {
+    animation: none;
+  }
+}


### PR DESCRIPTION
closes #617 

toast-provider.tsx applies `animate-slide-in` to each toast, but the animation was never defined (Tailwind v4, no tailwind.config), so toasts popped in abruptly with no motion.

globals.css:
- Add `@keyframes slide-in` (translateX(110%)/opacity 0 -> translateX(0)/ opacity 1) and `.animate-slide-in` running it at 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards
- Animate only transform + opacity (GPU-compositable) with will-change so the slide stays smooth on mobile
- Add an optional `slide-out` keyframe/`.animate-slide-out` helper (not wired — dismiss still removes the toast immediately, per the acceptance criteria)
- Disable both under prefers-reduced-motion

Verified: postcss parses globals.css cleanly; braces balanced.

- [ ] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
<!-- How do we revert if this breaks in production? -->

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.
