### PR TITLE
feat(backend): restart-safe ledger cursor persistence for EventListenerService (#619)

### DIFF
--- a/backend/src/entities/ServiceState.ts
+++ b/backend/src/entities/ServiceState.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+/**
+ * Generic key/value store for background-service state that must survive
+ * process restarts (Issue #619).
+ *
+ * The first consumer is the EventListenerService, which persists its latest
+ * processed Soroban event cursor under `event_listener_cursor` so the worker
+ * resumes from where it left off instead of replaying from `latestLedger - 100`.
+ */
+@Entity("service_state")
+export class ServiceState {
+  @PrimaryColumn({ type: "varchar", length: 128 })
+  key!: string;
+
+  @Column({ type: "text" })
+  value!: string;
+}

--- a/backend/src/migrations/1760000000001-AddServiceState.ts
+++ b/backend/src/migrations/1760000000001-AddServiceState.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddServiceState1760000000001 implements MigrationInterface {
+  name = "AddServiceState1760000000001";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "service_state" ("key" character varying(128) NOT NULL, "value" text NOT NULL, CONSTRAINT "PK_service_state_key" PRIMARY KEY ("key"))`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "service_state"`);
+  }
+}

--- a/backend/src/services/EventListenerService.ts
+++ b/backend/src/services/EventListenerService.ts
@@ -1,10 +1,14 @@
 import { getStellarRpcServer, loadStellarConfig, executeWithRetry } from "./stellar.js";
 import { getDataSource } from "./database.js";
 import { TransactionRecord } from "../entities/Transaction.js";
+import { ServiceState } from "../entities/ServiceState.js";
 import { logger } from "./logger.js";
 import { scValToNative } from "@stellar/stellar-sdk";
 import { fetchProjectById } from "./splits.service.js";
 import { publishSseEvent } from "./SseEventBus.js";
+
+/** ServiceState key under which the latest processed event cursor is persisted. */
+const EVENT_LISTENER_CURSOR_KEY = "event_listener_cursor";
 
 let pollInterval: NodeJS.Timeout | null = null;
 let isPolling = false;
@@ -20,20 +24,30 @@ export async function startEventListenerService() {
   logger.info("Starting EventListenerService background worker...");
 
   try {
-    const server = getStellarRpcServer();
-    const latestLedger = await executeWithRetry(() =>
-      server.getLatestLedger()
-    );
+    // Restart-safe resume: prefer the cursor persisted from the last run so we
+    // don't miss events that occurred while the server was down (Issue #619).
+    const dataSource = getDataSource();
+    const persisted = await dataSource
+      .getRepository(ServiceState)
+      .findOneBy({ key: EVENT_LISTENER_CURSOR_KEY });
 
-    // Start polling from 100 ledgers back to cover restart gaps
-    startLedger = Math.max(1, latestLedger.sequence - 100);
-
-    logger.info(
-      `Initialized EventListenerService to start polling from ledger: ${startLedger}`
-    );
+    if (persisted?.value) {
+      cursor = persisted.value;
+      startLedger = null;
+      logger.info("Resuming EventListenerService from persisted event cursor.");
+    } else {
+      // First run (no persisted cursor): start 100 ledgers back to cover a
+      // short startup gap.
+      const server = getStellarRpcServer();
+      const latestLedger = await executeWithRetry(() => server.getLatestLedger());
+      startLedger = Math.max(1, latestLedger.sequence - 100);
+      logger.info(
+        `Initialized EventListenerService to start polling from ledger: ${startLedger}`
+      );
+    }
   } catch (error) {
     logger.error(
-      "Failed to fetch latest ledger on EventListenerService startup. Polling from latest.",
+      "Failed to determine EventListenerService start position. Polling from latest.",
       { error }
     );
   }
@@ -87,106 +101,125 @@ export async function pollEvents() {
       server.getEvents(filterOptions)
     );
 
-    if (response?.events?.length) {
-      const records: TransactionRecord[] = [];
+    const newRecords: TransactionRecord[] = [];
+    const ssePayloads: Array<{
+      txHash: string;
+      roundId: string;
+      recipient: string;
+      amount: string;
+      token: string;
+      timestamp: number;
+      status: "completed";
+    }> = [];
 
-      for (const event of response.events) {
-        try {
-          const topics = event.topic.map((topic) => {
-            try {
-              return String(scValToNative(topic));
-            } catch {
-              return "";
-            }
-          });
-
-          // Check for `payment_sent` events
-          if (topics[0] === "payment_sent") {
-            const projectId = topics[1] || "";
-            const valueData = scValToNative(event.value) as [string, string | number | bigint];
-            const recipient = valueData[0];
-            const amount = String(valueData[1]);
-            const txHash = event.txHash;
-            const timestamp = Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000);
-
-            // Verify if transaction is already indexed. The database also enforces
-            // uniqueness on txHash via a unique index, but this application-layer
-            // check avoids duplicate save attempts during event polling.
-            const existing = await repo.findOneBy({ txHash });
-            if (!existing) {
-              // Retrieve project to get its token address
-              let token = "Native";
-              try {
-                const project = await fetchProjectById(projectId);
-                if (project && typeof project === "object" && "token" in project) {
-                  token = String(project.token);
-                }
-              } catch (err) {
-                logger.warn(`Could not resolve token address for project ${projectId}. Using fallback.`, { err });
-              }
-
-              const record = repo.create({
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                txHash,
-                status: "completed"
-              });
-
-              await repo.save(record);
-              logger.info(`Synced payout event to database: project=${projectId}, recipient=${recipient}, amount=${amount}, tx=${txHash}`);
-              publishSseEvent(txHash, {
-                txHash,
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                status: "completed"
-              });
-            }
-          } catch (err) {
-            logger.warn(
-              `Could not resolve token address for project ${projectId}. Using fallback.`,
-              { err }
-            );
+    for (const event of response?.events ?? []) {
+      try {
+        const topics = event.topic.map((topic) => {
+          try {
+            return String(scValToNative(topic));
+          } catch {
+            return "";
           }
-
-          records.push(
-            repo.create({
-              roundId: projectId,
-              recipient,
-              amount,
-              token,
-              timestamp,
-              txHash,
-              status: "completed",
-            })
-          );
-        } catch (eventError) {
-          logger.error("Error processing polled Soroban event", {
-            event,
-            error: eventError,
-          });
-        }
-      }
-
-      if (records.length > 0) {
-        await repo.upsert(records, {
-          conflictPaths: ["txHash"],
-          skipUpdateIfNoValuesChanged: true,
         });
 
+        // Only index `payment_sent` events.
+        if (topics[0] !== "payment_sent") {
+          continue;
+        }
+
+        const projectId = topics[1] || "";
+        const valueData = scValToNative(event.value) as [string, string | number | bigint];
+        const recipient = valueData[0];
+        const amount = String(valueData[1]);
+        const txHash = event.txHash;
+        const timestamp = Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000);
+
+        // Skip already-indexed transactions. The unique index on `txHash` plus
+        // the upsert below are the source of truth; this check just avoids
+        // redundant work and duplicate SSE emissions.
+        const existing = await repo.findOneBy({ txHash });
+        if (existing) {
+          continue;
+        }
+
+        // Resolve the project's token address (best-effort; falls back to Native).
+        let token = "Native";
+        try {
+          const project = await fetchProjectById(projectId);
+          if (project && typeof project === "object" && "token" in project) {
+            token = String(project.token);
+          }
+        } catch (err) {
+          logger.warn(
+            `Could not resolve token address for project ${projectId}. Using fallback.`,
+            { err }
+          );
+        }
+
+        newRecords.push(
+          repo.create({
+            roundId: projectId,
+            recipient,
+            amount,
+            token,
+            timestamp,
+            txHash,
+            status: "completed",
+          })
+        );
+        ssePayloads.push({
+          txHash,
+          roundId: projectId,
+          recipient,
+          amount,
+          token,
+          timestamp,
+          status: "completed",
+        });
+      } catch (eventError) {
+        logger.error("Error processing polled Soroban event", {
+          event,
+          error: eventError,
+        });
+      }
+    }
+
+    const nextCursor = response?.cursor ?? cursor;
+
+    // Persist the new records AND the advanced cursor in a single transaction,
+    // so after a restart we never skip events relative to what was committed,
+    // nor re-process a batch that was already committed (Issue #619).
+    if (newRecords.length > 0 || (nextCursor && nextCursor !== cursor)) {
+      await dataSource.transaction(async (manager) => {
+        if (newRecords.length > 0) {
+          await manager.upsert(TransactionRecord, newRecords, {
+            conflictPaths: ["txHash"],
+            skipUpdateIfNoValuesChanged: true,
+          });
+        }
+        if (nextCursor) {
+          await manager.upsert(
+            ServiceState,
+            { key: EVENT_LISTENER_CURSOR_KEY, value: nextCursor },
+            { conflictPaths: ["key"] }
+          );
+        }
+      });
+
+      if (newRecords.length > 0) {
         logger.info(
-          `Upserted ${records.length} transaction record(s) from current event batch.`
+          `Upserted ${newRecords.length} transaction record(s) from current event batch.`
         );
       }
+    }
 
-      if (response.cursor) {
-        cursor = response.cursor;
-      }
+    // Advance the in-memory cursor and emit SSE only after a successful commit.
+    if (nextCursor) {
+      cursor = nextCursor;
+      startLedger = null;
+    }
+    for (const payload of ssePayloads) {
+      publishSseEvent(payload.txHash, payload);
     }
   } catch (error) {
     logger.error("Error occurred in background Soroban event poll", {

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -3,6 +3,7 @@ import { DataSource, type QueryRunner } from "typeorm";
 import { getEnv } from "../config/env.js";
 import { User } from "../entities/User.js";
 import { TransactionRecord } from "../entities/Transaction.js";
+import { ServiceState } from "../entities/ServiceState.js";
 import { logger } from "./logger.js";
 
 let AppDataSource: DataSource | null = null;
@@ -45,7 +46,7 @@ export function createDataSource(): DataSource {
     url: databaseUrl,
     synchronize: false,
     logging: process.env.NODE_ENV === "development",
-    entities: [User, TransactionRecord],
+    entities: [User, TransactionRecord, ServiceState],
     migrations: ["src/migrations/*.ts"],
     migrationsTableName: "migrations",
     extra: {


### PR DESCRIPTION
closes #619 

EventListenerService kept `cursor`/`startLedger` only in module-level memory, so a restart resumed from `latestLedger - 100` and could miss events during any downtime longer than ~100 ledgers (~8 min on testnet).

- Add ServiceState entity (generic key/value store) + migration (1760000000001-AddServiceState) creating the `service_state` table; register the entity on the DataSource
- startEventListenerService(): load the persisted cursor (`event_listener_cursor`) and resume from it; only fall back to latestLedger - 100 on first run
- pollEvents(): persist the advanced cursor and the new TransactionRecords in a single DB transaction (dataSource.transaction), so a restart can neither skip nor replay a committed batch; advance the in-memory cursor and emit SSE only after the commit

Also repairs a pre-existing syntax error in pollEvents (an `if { } catch` block with no `try`, plus duplicated/out-of-scope record handling) that was breaking the build — the rewrite is the same code path #619 touches.

Verified: my files have zero tsc and zero eslint errors (the backend build/lint are otherwise pre-existingly red on main — 48 type errors, a TS5103 ignoreDeprecations "6.0" vs typescript 5.8.2 mismatch, and 7 lint errors — all in unrelated files).
- [ ] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
<!-- How do we revert if this breaks in production? -->

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.
