### PR TITLE
ci(testnet): nightly API integration suite against live Soroban testnet (#369)

### DIFF
--- a/.github/workflows/testnet-integration.yml
+++ b/.github/workflows/testnet-integration.yml
@@ -1,0 +1,104 @@
+name: Testnet Integration (Nightly)
+
+# Issue #369: run the API happy-path against a real Soroban testnet so that
+# RPC/contract breaking changes are caught before they reach deployment.
+# Unit tests mock RPC; this exercises the live network.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Required configuration (GitHub → Settings → Environments → "testnet")
+#
+#   Secrets:
+#     STELLAR_TESTNET_CONTRACT_ID     Deployed SplitNaira contract id (C...)
+#     STELLAR_TESTNET_SOURCE_ACCOUNT  A funded testnet account public key (G...)
+#                                     used as the simulation source / owner.
+#   Optional secrets (enable extra steps):
+#     STELLAR_TESTNET_TOKEN           A SAC token contract id (C...) — enables
+#                                     the create_project build/simulate step.
+#     STELLAR_TESTNET_PROJECT_ID      An existing on-chain project id — enables
+#                                     the deposit build/simulate step.
+#
+# The public testnet endpoints (RPC, Horizon, network passphrase) are set as
+# defaults below and rarely need overriding.
+# ─────────────────────────────────────────────────────────────────────────────
+
+on:
+  schedule:
+    # 03:00 UTC nightly
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      project_id:
+        description: "Optional existing testnet project id (enables deposit step)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  testnet-integration:
+    name: API happy-path against live testnet
+    runs-on: ubuntu-latest
+    environment: testnet # provides the STELLAR_TESTNET_* secrets
+
+    env:
+      RUN_TESTNET_INTEGRATION: "1"
+      # Public testnet endpoints (override via env if needed).
+      SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+      HORIZON_URL: "https://horizon-testnet.stellar.org"
+      SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015"
+      # From the "testnet" environment secrets.
+      CONTRACT_ID: ${{ secrets.STELLAR_TESTNET_CONTRACT_ID }}
+      SIMULATOR_ACCOUNT: ${{ secrets.STELLAR_TESTNET_SOURCE_ACCOUNT }}
+      TESTNET_SOURCE_ACCOUNT: ${{ secrets.STELLAR_TESTNET_SOURCE_ACCOUNT }}
+      TESTNET_TOKEN: ${{ secrets.STELLAR_TESTNET_TOKEN }}
+      TESTNET_PROJECT_ID: ${{ inputs.project_id || secrets.STELLAR_TESTNET_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Verify required secrets are configured
+        run: |
+          missing=""
+          [ -n "$CONTRACT_ID" ] || missing="$missing STELLAR_TESTNET_CONTRACT_ID"
+          [ -n "$TESTNET_SOURCE_ACCOUNT" ] || missing="$missing STELLAR_TESTNET_SOURCE_ACCOUNT"
+          if [ -n "$missing" ]; then
+            echo "❌ Missing required testnet secrets:$missing" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "Configure them under the repo's \"testnet\" environment." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Run testnet integration suite
+        id: integration
+        run: npm run test:integration -w backend -- --reporter=verbose
+
+      - name: Report result to workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Testnet Integration — ${{ steps.integration.outcome }}"
+            echo ""
+            if [ "${{ steps.integration.outcome }}" = "success" ]; then
+              echo "✅ The API happy-path succeeded against the live Soroban testnet."
+            else
+              echo "❌ The API happy-path FAILED against the live Soroban testnet."
+              echo "This usually means an RPC change, a redeployed/incompatible contract,"
+              echo "or an unfunded source account. Check the \"Run testnet integration suite\" logs."
+            fi
+            echo ""
+            echo "| Setting | Value |"
+            echo "| --- | --- |"
+            echo "| RPC | \`$SOROBAN_RPC_URL\` |"
+            echo "| Contract | \`${CONTRACT_ID:-<unset>}\` |"
+            echo "| Source account | \`${TESTNET_SOURCE_ACCOUNT:0:6}…\` |"
+            echo "| create_project step | $([ -n "$TESTNET_TOKEN" ] && echo enabled || echo 'skipped (no STELLAR_TESTNET_TOKEN)') |"
+            echo "| deposit step | $([ -n "$TESTNET_PROJECT_ID" ] && echo enabled || echo 'skipped (no project id)') |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "test": "vitest run",
     "test:compat": "vitest run src/routes/splits.compatibility.test.ts",
+    "test:integration": "vitest run src/__tests__/e2e-testnet.integration.test.ts",
     "test:watch": "vitest --watch",
     "deps:check": "npm ls --all --omit=optional",
     "generate:openapi": "tsx src/openapi.ts",

--- a/backend/src/__tests__/e2e-testnet.integration.test.ts
+++ b/backend/src/__tests__/e2e-testnet.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Issue #369: Live testnet integration test (nightly)
+ *
+ * Unlike `e2e-happy-path.test.ts` (which mocks all Stellar RPC for reproducible
+ * unit runs), this suite exercises the same happy-path flow against a REAL
+ * Soroban testnet so deployment-breaking RPC/contract changes are caught early.
+ *
+ * It is gated behind `RUN_TESTNET_INTEGRATION=1` and the required testnet
+ * config, so it is SKIPPED in normal CI/unit runs and only executes in the
+ * scheduled `testnet-integration` workflow (which injects the secrets).
+ *
+ * The API builds/simulates unsigned XDR, so a "happy path" here means each
+ * endpoint successfully reaches the live RPC and the deployed contract:
+ *   - create_project  → real getAccount + simulate against the contract
+ *   - history         → real getEvents + event decoding
+ *   - deposit (opt.)  → build/simulate against an existing testnet project
+ * No transaction is signed or submitted (the API never signs).
+ *
+ * Required env (set by the workflow from secrets):
+ *   RUN_TESTNET_INTEGRATION=1
+ *   SOROBAN_RPC_URL, SOROBAN_NETWORK_PASSPHRASE, HORIZON_URL, CONTRACT_ID
+ *   SIMULATOR_ACCOUNT and/or TESTNET_SOURCE_ACCOUNT  (a funded testnet G... key)
+ * Optional:
+ *   TESTNET_TOKEN       (a SAC contract id; enables the create_project step)
+ *   TESTNET_PROJECT_ID  (an existing project; enables the deposit step)
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+
+import { app } from "../index.js";
+
+const RUN = process.env.RUN_TESTNET_INTEGRATION === "1";
+const suite = RUN ? describe : describe.skip;
+
+const SOURCE = process.env.TESTNET_SOURCE_ACCOUNT || process.env.SIMULATOR_ACCOUNT || "";
+const TOKEN = process.env.TESTNET_TOKEN || "";
+const EXISTING_PROJECT_ID = process.env.TESTNET_PROJECT_ID || "";
+
+suite("E2E (live testnet): happy-path build/simulate against real RPC", () => {
+  beforeAll(() => {
+    const required = ["SOROBAN_RPC_URL", "SOROBAN_NETWORK_PASSPHRASE", "HORIZON_URL", "CONTRACT_ID"];
+    const missing = required.filter((key) => !process.env[key]);
+    if (missing.length > 0) {
+      throw new Error(`Missing required testnet env: ${missing.join(", ")}`);
+    }
+    if (!SOURCE) {
+      throw new Error("Set TESTNET_SOURCE_ACCOUNT or SIMULATOR_ACCOUNT to a funded testnet account.");
+    }
+  });
+
+  // Always-on: needs only CONTRACT_ID + RPC. Verifies the event pipeline
+  // (getEvents + decoding) against the live network.
+  it("history endpoint reaches live getEvents and returns a decoded list", async () => {
+    const id = EXISTING_PROJECT_ID || `nightly_probe_${Date.now()}`;
+    const res = await request(app).get(`/splits/${id}/history`);
+
+    expect(res.status, `[history] ${JSON.stringify(res.body)}`).toBe(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+  });
+
+  // Needs a funded source + a real SAC token. Verifies getAccount + simulate
+  // against the deployed contract's create_project entry point.
+  it.runIf(TOKEN !== "")(
+    "create_project builds and simulates against the live contract",
+    async () => {
+      const projectId = `nightly_${Date.now()}`;
+      const res = await request(app)
+        .post("/splits")
+        .send({
+          owner: SOURCE,
+          projectId,
+          title: "Nightly Testnet Integration",
+          projectType: "music",
+          token: TOKEN,
+          collaborators: [{ address: SOURCE, alias: "Nightly", basisPoints: 10000 }],
+        });
+
+      expect(res.status, `[create] ${JSON.stringify(res.body)}`).toBe(200);
+      expect(typeof res.body.xdr).toBe("string");
+      expect(res.body.metadata).toMatchObject({ operation: "create_project", sourceAccount: SOURCE });
+    },
+  );
+
+  // Needs an existing on-chain project. Verifies deposit build/simulate against
+  // real project state.
+  it.runIf(EXISTING_PROJECT_ID !== "")(
+    "deposit builds and simulates against an existing testnet project",
+    async () => {
+      const res = await request(app)
+        .post(`/splits/${EXISTING_PROJECT_ID}/deposit`)
+        .send({ from: SOURCE, amount: 10_000_000 });
+
+      expect(res.status, `[deposit] ${JSON.stringify(res.body)}`).toBe(200);
+      expect(typeof res.body.xdr).toBe("string");
+    },
+  );
+});


### PR DESCRIPTION
closes #369 

Unit tests mock RPC; deployment needs confidence against a real testnet. This adds a scheduled (and manually dispatchable) workflow that runs the API happy-path against live testnet so RPC/contract breaking changes are caught before deploy.

- .github/workflows/testnet-integration.yml: nightly cron + workflow_dispatch, runs under the "testnet" environment, injects public testnet endpoints + STELLAR_TESTNET_* secrets, runs the integration suite, and reports pass/fail to the workflow summary (with failure guidance). Required/optional secrets are documented in the workflow header.
- backend/src/__tests__/e2e-testnet.integration.test.ts: live counterpart to e2e-happy-path.test.ts (same flow, no RPC mocks). Gated behind RUN_TESTNET_INTEGRATION=1 + required config, so it is SKIPPED in normal CI and only runs in the nightly workflow. Steps: history (getEvents), create_project (getAccount + simulate), and an optional deposit build against an existing project.
- backend/package.json: add `test:integration` script.

Verified: gated off, the suite skips cleanly (1 file / 3 tests skipped) and does not affect the normal test run; workflow YAML validated.

Note: requires the EventListenerService syntax fix from #619 to be on the base branch for the backend (and therefore this suite) to load.
### Contract changes
- [ ] No contract changes
- [ ] Contract changes included — migration plan: <!-- describe -->

### Database migrations
- [ ] No migrations
- [ ] Migration included — rollback script: <!-- path -->

### Environment variables
- [ ] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
<!-- How do we revert if this breaks in production? -->

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.
