### PR TITLE
feat(contracts): scale & capacity - restore build + configurable collaborator cap (#511)

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -59,6 +59,19 @@ Removes a token from allowlist.
 - Auth: contract admin.
 - Errors: `AdminNotSet`, `Unauthorized`.
 
+### `set_max_collaborators(admin: Address, value: u32) -> Result<(), SplitError>`
+Configures the per-project collaborator cap (Scale & Capacity tuning).
+- Auth: contract admin.
+- Bounds: `2 <= value <= 200`. The ceiling keeps `distribute` within Soroban's
+  per-call resource limits; the floor matches the two-collaborator minimum.
+- Default when never set: `50` (historical behaviour, backward compatible).
+- Rollback: set the value back to `50`. Only affects validation of *new*
+  `create_project` / `update_collaborators` calls.
+- Errors: `AdminNotSet`, `Unauthorized`, `InvalidMaxCollaborators`.
+
+### `get_max_collaborators() -> u32`
+Returns the collaborator cap currently in effect (admin override or default `50`).
+
 ### Project lifecycle
 
 ### `create_project(owner, project_id, title, project_type, token, collaborators) -> Result<(), SplitError>`
@@ -261,6 +274,13 @@ Soroban event shape is `(topics, data)`. This contract uses `topics = (event_nam
   - Topics: `("collaborators_updated", "afrobeats_vol3")`
   - Data: `"afrobeats_vol3"`
 
+### `max_collaborators_set`
+- Topics format: `("max_collaborators_set", admin)`
+- Data format: `value` (the new per-project collaborator cap)
+- Example:
+  - Topics: `("max_collaborators_set", "G...ADMIN")`
+  - Data: `75`
+
 ## Error Codes
 
 - `1` `ProjectExists`
@@ -282,3 +302,5 @@ Soroban event shape is `(topics, data)`. This contract uses `topics = (event_nam
 - `17` `InvalidRecipient`
 - `18` `NotACollaborator`
 - `19` `TooManyCollaborators`
+- `20` `AccountingDiscrepancy`
+- `21` `InvalidMaxCollaborators`

--- a/contracts/errors.rs
+++ b/contracts/errors.rs
@@ -90,11 +90,17 @@ pub enum SplitError {
     // Arithmetic Errors
     // ---------------------------------------------------------------------
 
-    /// Project has exceeded the maximum allowed number of collaborators
-    TooManyCollaborators = 19,
-
     /// Cached accounted balance exceeds the contract's actual token balance
     AccountingDiscrepancy = 20,
+
+    /// Admin-supplied capacity limit is outside the permitted range.
+    InvalidMaxCollaborators = 21,
+
+    /// An arithmetic operation overflowed.
+    ///
+    /// Code `14` matches the value already published in the README error-code
+    /// table; the variant was referenced in `lib.rs` but had never been declared.
+    ArithmeticOverflow = 14,
 }
 
 impl SplitError {

--- a/contracts/events.rs
+++ b/contracts/events.rs
@@ -495,7 +495,8 @@ impl Publishable for SplitsUpdatedWithPendingBalance {
     fn publish(&self, env: &Env) {
         env.events().publish(
             (
-                Symbol::new(env, "splits_updated_with_pending_balance"),
+                // Soroban Symbols are capped at 32 chars; keep this <= 32.
+                Symbol::new(env, "splits_updated_pending_balance"),
                 self.project_id.clone(),
             ),
             self.pending_balance,
@@ -572,6 +573,29 @@ impl AccountingDiscrepancy {
         env.events().publish(
             (Symbol::new(env, "accounting_discrepancy"), self.token.clone()),
             (self.contract_balance, self.accounted_balance),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MaxCollaboratorsUpdated
+// ---------------------------------------------------------------------------
+
+/// Emitted when the admin reconfigures the per-project collaborator cap.
+///
+/// **Topics:** `["max_collaborators_set", admin]`
+/// **Data:** `value` (the new cap)
+#[derive(Clone, Debug)]
+pub struct MaxCollaboratorsUpdated {
+    pub admin: Address,
+    pub value: u32,
+}
+
+impl Publishable for MaxCollaboratorsUpdated {
+    fn publish(&self, env: &Env) {
+        env.events().publish(
+            (Symbol::new(env, "max_collaborators_set"), self.admin.clone()),
+            self.value,
         );
     }
 }

--- a/contracts/hardening_tests.rs
+++ b/contracts/hardening_tests.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+extern crate std;
+
 use dx_tooling::validator::run_checks;
 
 /// Source code of the contract under test.
@@ -41,7 +43,7 @@ fn validator_detects_missing_authorization() {
         violations
     );
 
-    let violations_text = format!("{:#?}", violations);
+    let violations_text = std::format!("{:#?}", violations);
 
     assert!(
         violations_text.contains("claim"),

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -13,6 +13,8 @@ const PROJECT_ID_BUCKET_SIZE: u32 = 100;
 mod errors;
 mod events;
 use events::{
+    Publishable,
+    MaxCollaboratorsUpdated,
     CollaboratorsUpdated,
     DepositReceived,
     DistributionComplete,
@@ -55,8 +57,26 @@ const PROJECT_TTL_THRESHOLD_LEDGERS: u32 = 50_000;
 /// these hard-coded constants should be considered for migration into configurable instance-storage values.
 const PROJECT_TTL_BUMP_LEDGERS: u32 = 100_000;
 
-/// Maximum number of collaborators allowed in a single project
-const MAX_COLLABORATORS: u32 = 50;
+/// Default maximum number of collaborators allowed in a single project.
+///
+/// This is the value used when no admin override has been configured via
+/// [`SplitNairaContract::set_max_collaborators`]. Keeping it as the default
+/// preserves the historical contract behaviour for existing deployments.
+const DEFAULT_MAX_COLLABORATORS: u32 = 50;
+
+/// Minimum value an admin may configure for the collaborator cap.
+///
+/// A project always requires at least two collaborators (see
+/// [`SplitError::TooFewCollaborators`]), so the cap can never be set below this.
+const MIN_MAX_COLLABORATORS: u32 = 2;
+
+/// Hard upper bound on the admin-configurable collaborator cap.
+///
+/// `distribute` iterates over every collaborator within a single transaction,
+/// so the cap is bounded to keep each distribution within Soroban's per-call
+/// resource limits. This ceiling protects the contract from being configured
+/// into a state where distributions can no longer fit in a ledger.
+const MAX_MAX_COLLABORATORS: u32 = 200;
 
 // ============================================================
 //  DATA TYPES
@@ -134,6 +154,9 @@ pub enum DataKey {
     AccountedTokenBalance(Address),
     /// Global flag to pause all distributions (emergency stop)
     DistributionsPaused,
+    /// Admin-configurable per-project collaborator cap.
+    /// When unset, the contract falls back to `DEFAULT_MAX_COLLABORATORS`.
+    MaxCollaborators,
 }
 
 /// Returned by `get_claimable`: how much a collaborator has received and the
@@ -228,6 +251,64 @@ impl SplitNairaContract {
         }
         .publish(&env);
         Ok(())
+    }
+
+    /// Returns the per-project collaborator cap currently in effect.
+    ///
+    /// This is the admin-configured value if one has been set via
+    /// [`Self::set_max_collaborators`], otherwise [`DEFAULT_MAX_COLLABORATORS`].
+    /// Existing deployments that never call the setter keep the default, so this
+    /// is fully backward compatible.
+    pub fn get_max_collaborators(env: Env) -> u32 {
+        Self::effective_max_collaborators(&env)
+    }
+
+    /// Configures the per-project collaborator cap (Scale & Capacity tuning).
+    ///
+    /// Only the contract admin may call this. The value is bounded to
+    /// `[MIN_MAX_COLLABORATORS, MAX_MAX_COLLABORATORS]` so distributions always
+    /// remain executable within Soroban's per-call resource limits.
+    ///
+    /// # Rollback
+    /// To revert to the original behaviour, set the value back to
+    /// `DEFAULT_MAX_COLLABORATORS` (50). The override only affects validation of
+    /// *new* `create_project` / `update_collaborators` calls; projects created
+    /// while a higher cap was active are unaffected by a later reduction.
+    ///
+    /// # Errors
+    /// * `SplitError::Unauthorized`           - caller is not the admin
+    /// * `SplitError::AdminNotSet`            - admin has not been configured
+    /// * `SplitError::InvalidMaxCollaborators`- value outside the allowed range
+    pub fn set_max_collaborators(
+        env: Env,
+        admin: Address,
+        value: u32,
+    ) -> Result<(), SplitError> {
+        Self::require_contract_admin(&env, &admin)?;
+
+        if value < MIN_MAX_COLLABORATORS || value > MAX_MAX_COLLABORATORS {
+            return Err(SplitError::InvalidMaxCollaborators);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxCollaborators, &value);
+
+        MaxCollaboratorsUpdated {
+            admin: admin.clone(),
+            value,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Resolves the effective collaborator cap: the admin override if present,
+    /// otherwise the compiled-in default.
+    fn effective_max_collaborators(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get::<DataKey, u32>(&DataKey::MaxCollaborators)
+            .unwrap_or(DEFAULT_MAX_COLLABORATORS)
     }
 
     /// Adds a token contract address to the allowlist.
@@ -1366,7 +1447,7 @@ if balance < project.collaborators.len() as i128 {
             return Err(SplitError::TooFewCollaborators);
         }
 
-        if collaborators.len() > MAX_COLLABORATORS {
+        if collaborators.len() > Self::effective_max_collaborators(env) {
             return Err(SplitError::TooManyCollaborators);
         }
 

--- a/contracts/tests.rs
+++ b/contracts/tests.rs
@@ -817,7 +817,7 @@ fn test_update_collaborators_with_pending_balance_emits_warning() {
     let mut warning_emitted = false;
     for event in events.iter() {
         if let Ok(topic) = Symbol::try_from_val(&env, &event.1.get(0).unwrap()) {
-            if topic == Symbol::new(&env, "splits_updated_with_pending_balance") {
+            if topic == Symbol::new(&env, "splits_updated_pending_balance") {
                 warning_emitted = true;
                 assert_eq!(
                     Symbol::try_from_val(&env, &event.1.get(1).unwrap()).unwrap(),
@@ -4173,4 +4173,134 @@ fn test_batch_distribute_fails_when_paused_batch() {
     let result = client.try_batch_distribute(&batch);
     
     assert_eq!(result, Err(Ok(SplitError::DistributionsPaused)));
+}
+
+// ============================================================
+//  CONFIGURABLE CAPACITY: MAX_COLLABORATORS  (Issue #511)
+// ============================================================
+
+#[test]
+fn test_max_collaborators_defaults_to_50() {
+    let (env, _admin, _token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    // With no override configured, the effective cap is the historical default.
+    assert_eq!(client.get_max_collaborators(), 50);
+}
+
+#[test]
+fn test_set_max_collaborators_updates_effective_cap() {
+    let (env, _admin, _token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    client.set_max_collaborators(&admin, &10);
+    assert_eq!(client.get_max_collaborators(), 10);
+
+    // Reconfigure again to confirm the override is mutable.
+    client.set_max_collaborators(&admin, &200);
+    assert_eq!(client.get_max_collaborators(), 200);
+}
+
+#[test]
+fn test_set_max_collaborators_requires_admin() {
+    let (env, _admin, _token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    // No admin configured yet.
+    let stranger = Address::generate(&env);
+    assert_eq!(
+        client.try_set_max_collaborators(&stranger, &10),
+        Err(Ok(SplitError::AdminNotSet))
+    );
+
+    // Admin set, but a different caller is rejected.
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    let other = Address::generate(&env);
+    assert_eq!(
+        client.try_set_max_collaborators(&other, &10),
+        Err(Ok(SplitError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_set_max_collaborators_rejects_out_of_range() {
+    let (env, _admin, _token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    // Below the floor (a project always needs >= 2 collaborators).
+    assert_eq!(
+        client.try_set_max_collaborators(&admin, &1),
+        Err(Ok(SplitError::InvalidMaxCollaborators))
+    );
+    // Above the resource-safety ceiling.
+    assert_eq!(
+        client.try_set_max_collaborators(&admin, &201),
+        Err(Ok(SplitError::InvalidMaxCollaborators))
+    );
+
+    // Boundaries are accepted.
+    client.set_max_collaborators(&admin, &2);
+    assert_eq!(client.get_max_collaborators(), 2);
+    client.set_max_collaborators(&admin, &200);
+    assert_eq!(client.get_max_collaborators(), 200);
+}
+
+#[test]
+fn test_lowered_cap_is_enforced_on_create_project() {
+    let (env, _admin, token) = create_test_env();
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+
+    // Tighten capacity to exactly two collaborators.
+    client.set_max_collaborators(&admin, &2);
+
+    let owner = Address::generate(&env);
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    // Two collaborators: allowed under the new cap.
+    let two = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[a.clone(), b.clone()]),
+        Vec::from_slice(&env, &[5000u32, 5000u32]),
+    );
+    client.create_project(
+        &owner,
+        &Symbol::new(&env, "cap_ok"),
+        &String::from_str(&env, "Cap OK"),
+        &String::from_str(&env, "music"),
+        &token,
+        &two,
+    );
+
+    // Three collaborators: now exceeds the configured cap.
+    let three = make_collaborators(
+        &env,
+        Vec::from_slice(&env, &[a.clone(), b.clone(), c.clone()]),
+        Vec::from_slice(&env, &[4000u32, 4000u32, 2000u32]),
+    );
+    let result = client.try_create_project(
+        &owner,
+        &Symbol::new(&env, "cap_bad"),
+        &String::from_str(&env, "Cap Bad"),
+        &String::from_str(&env, "music"),
+        &token,
+        &three,
+    );
+    assert_eq!(result, Err(Ok(SplitError::TooManyCollaborators)));
 }

--- a/docs/CONTRACTS_SCALE_CAPACITY_WAVE5.md
+++ b/docs/CONTRACTS_SCALE_CAPACITY_WAVE5.md
@@ -1,0 +1,83 @@
+# Contracts — Scale & Capacity (Wave 5)
+
+Issue: Split-Naira/SplitNaira #511 — *[Contracts] Scale & Capacity – Wave 5 execution track*
+
+This track restores the contract to a deployable state and adds an operator
+lever for per-project capacity. It is split into two parts: **deployment-readiness
+repairs** (the contract did not compile on `main`) and a **configurable capacity
+limit**.
+
+## 1. Audit findings — contract was not deploy-ready
+
+`cargo build --target wasm32-unknown-unknown --release` failed on `main`, so the
+WASM could not be produced and **no tests could run**. Five distinct defects were
+found and fixed:
+
+| # | Defect | Symptom | Fix |
+|---|--------|---------|-----|
+| 1 | `SplitError::TooManyCollaborators` declared twice (`= 19`) | `E0428` / `E0081`, `contracterror` macro failure cascading into ~20 errors | Removed the duplicate variant |
+| 2 | `Publishable` trait not imported in `lib.rs` | 15× `no method named publish` (`E0599`) | Imported `events::Publishable` |
+| 3 | `SplitError::ArithmeticOverflow` referenced but never declared | 3× `no variant ArithmeticOverflow` (`E0599`) | Declared `ArithmeticOverflow = 14` (the code already documented in the README error table) |
+| 4 | `format!` used without `extern crate std` in `hardening_tests.rs` | `cannot find macro format` in the test build | Added `extern crate std;` + qualified `std::format!` |
+| 5 | Event topic `splits_updated_with_pending_balance` (35 chars) | Soroban `Symbol` is capped at 32 chars → **non-unwinding host abort** whenever `update_collaborators` ran with a pending balance | Shortened to `splits_updated_pending_balance` (30 chars) |
+
+After these repairs: WASM builds clean and the full suite passes
+(**102 tests**, including 5 new ones for the capacity feature).
+
+> Defect #5 is the most operationally significant: it was a latent runtime abort
+> on a real user path (`update_collaborators` on a funded project), only masked
+> because the contract never compiled.
+
+## 2. Feature — configurable `MAX_COLLABORATORS`
+
+The per-project collaborator cap was a hard-coded constant (`50`) with an in-code
+TODO to make it configurable. It is now an admin-tunable instance-storage value.
+
+New entrypoints:
+
+- `set_max_collaborators(admin: Address, value: u32)` — admin-only. Bounds:
+  `2 <= value <= 200`.
+- `get_max_collaborators() -> u32` — returns the effective cap.
+- Event `max_collaborators_set` (topics `("max_collaborators_set", admin)`, data `value`).
+
+### Bounds rationale
+- **Floor (2):** a project always requires at least two collaborators.
+- **Ceiling (200):** `distribute` iterates over every collaborator in a single
+  transaction, so the cap is bounded to keep each distribution within Soroban's
+  per-call instruction/resource limits. The ceiling prevents an operator from
+  configuring the contract into a state where distributions can no longer fit in
+  a ledger.
+
+## 3. Operational impact
+
+- **Backward compatible / deploy-safe.** When the override has never been set,
+  `effective_max_collaborators` falls back to the default `50`, so existing
+  deployments behave exactly as before. No migration step is required.
+- **Scope of effect.** The cap is only consulted when validating *new*
+  `create_project` and `update_collaborators` calls. Already-stored projects are
+  never re-validated, so changing the cap cannot retroactively invalidate or
+  brick an existing project.
+- **Auditability.** Every change emits `max_collaborators_set`, so capacity
+  changes are observable on-chain by indexers/monitoring.
+
+## 4. Rollback notes
+
+- **Feature rollback (no redeploy):** call
+  `set_max_collaborators(admin, 50)` to return to the historical default. Because
+  the value lives in instance storage and reads fall back to the default, there is
+  no broken intermediate state.
+- **A reduction never harms existing projects.** Lowering the cap below the size
+  of an existing project does not affect that project; the owner simply cannot
+  grow it beyond the new cap on the next `update_collaborators`.
+- **Code rollback:** reverting this PR returns the contract to the previous
+  *non-compiling* state, so a redeploy from the prior commit is **not** possible.
+  Prefer the on-chain `set_max_collaborators(admin, 50)` rollback above; reserve a
+  full code revert for a fresh build from a known-good commit.
+
+## 5. Verification
+
+```bash
+cd contracts
+cargo build --target wasm32-unknown-unknown --release   # WASM builds
+cargo test                                              # 102 passed; 0 failed
+```


### PR DESCRIPTION
closes #511

Audit found the contract did not compile on main, so the WASM could not be built and no tests ran. This restores deploy-readiness and adds an operator lever for per-project capacity.

Deployment-readiness repairs (5):
- errors.rs: remove duplicate `TooManyCollaborators = 19` (E0428/E0081 cascade)
- lib.rs: import `events::Publishable` (15x missing `.publish()`)
- errors.rs: declare `ArithmeticOverflow = 14` (referenced, never defined; code 14 matches the README error table)
- hardening_tests.rs: `extern crate std` + qualify `std::format!` (no_std)
- events.rs: shorten event Symbol `splits_updated_with_pending_balance` (35 chars) to `splits_updated_pending_balance` (Soroban Symbol cap is 32) — this was a latent non-unwinding host abort on update_collaborators with a pending balance

Feature - configurable MAX_COLLABORATORS:
- set_max_collaborators(admin, value) / get_max_collaborators() (instance storage)
- bounds [2, 200]; default 50 preserved when unset (backward compatible)
- emits `max_collaborators_set`; validate_collaborators uses the effective cap

Docs: README method/event/error-code entries; docs/CONTRACTS_SCALE_CAPACITY_WAVE5.md runbook with audit table, operational impact, and rollback notes.

Verified: wasm release builds; `cargo test` 102 passed / 0 failed.
