### PR TITLE
feat(backend): handle Stellar RPC outage gracefully in EventListenerS…

### DIFF
--- a/backend/src/__tests__/event-listener-backoff.test.ts
+++ b/backend/src/__tests__/event-listener-backoff.test.ts
@@ -1,0 +1,156 @@
+/**
+ * EventListenerService resilience tests (Issue #627)
+ *
+ * Verifies the Stellar RPC outage handling:
+ *  - poll interval backs off to 30s after 3 consecutive errors,
+ *  - the interval resets to 5s on the first successful poll after a streak,
+ *  - getServiceHealth() reflects status / consecutiveErrors / lastSuccessfulPoll,
+ *  - the catch-up window is capped at MAX_CATCHUP_LEDGERS.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Shared mock handles, hoisted so the vi.mock factories below can close over them.
+const mocks = vi.hoisted(() => {
+  const getEvents = vi.fn();
+  const getLatestLedger = vi.fn(async () => ({ sequence: 1000 }));
+  return {
+    getEvents,
+    getLatestLedger,
+    repo: {
+      findOneBy: vi.fn(async () => null),
+      create: vi.fn((x: unknown) => x),
+      upsert: vi.fn(async () => undefined),
+    },
+  };
+});
+
+vi.mock("../services/stellar.js", () => ({
+  getStellarRpcServer: () => ({
+    getEvents: mocks.getEvents,
+    getLatestLedger: mocks.getLatestLedger,
+  }),
+  // Pass-through so the wrapped call's success/failure propagates directly.
+  executeWithRetry: <T>(fn: () => Promise<T>) => fn(),
+  loadStellarConfig: () => ({ contractId: "CONTRACT" }),
+}));
+
+vi.mock("../services/database.js", () => ({
+  getDataSource: () => ({ getRepository: () => mocks.repo }),
+}));
+
+vi.mock("../services/splits.service.js", () => ({
+  fetchProjectById: vi.fn(async () => ({ token: "Native" })),
+}));
+
+vi.mock("../services/SseEventBus.js", () => ({
+  publishSseEvent: vi.fn(),
+}));
+
+vi.mock("@stellar/stellar-sdk", () => ({
+  scValToNative: (v: unknown) => v,
+}));
+
+vi.mock("../services/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+type ListenerModule = typeof import("../services/EventListenerService.js");
+
+async function freshModule(): Promise<ListenerModule> {
+  vi.resetModules();
+  return import("../services/EventListenerService.js");
+}
+
+function lastIntervalDelay(spy: ReturnType<typeof vi.spyOn>): number | undefined {
+  const calls = spy.mock.calls;
+  if (calls.length === 0) return undefined;
+  return calls[calls.length - 1][1] as number;
+}
+
+let mod: ListenerModule;
+let setIntervalSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  mocks.getEvents.mockReset();
+  mocks.getLatestLedger.mockReset().mockResolvedValue({ sequence: 1000 });
+  setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+  mod = await freshModule();
+});
+
+afterEach(() => {
+  mod.stopEventListenerService();
+  setIntervalSpy.mockRestore();
+});
+
+describe("EventListenerService - RPC outage back-off", () => {
+  it("starts healthy at the normal 5s cadence", async () => {
+    mocks.getEvents.mockResolvedValue({ events: [] });
+    await mod.startEventListenerService();
+
+    expect(lastIntervalDelay(setIntervalSpy)).toBe(mod.NORMAL_POLL_INTERVAL_MS);
+    expect(mod.getServiceHealth().status).toBe("healthy");
+    expect(mod.getServiceHealth().consecutiveErrors).toBe(0);
+  });
+
+  it("backs off to 30s after 3 consecutive errors", async () => {
+    mocks.getEvents.mockRejectedValue(new Error("RPC down"));
+    await mod.startEventListenerService();
+
+    await mod.pollEvents();
+    expect(mod.getServiceHealth().consecutiveErrors).toBe(1);
+    expect(mod.getServiceHealth().status).toBe("healthy"); // not degraded yet
+
+    await mod.pollEvents();
+    expect(mod.getServiceHealth().consecutiveErrors).toBe(2);
+
+    await mod.pollEvents();
+    expect(mod.getServiceHealth().consecutiveErrors).toBe(3);
+    expect(mod.getServiceHealth().status).toBe("degraded");
+    expect(lastIntervalDelay(setIntervalSpy)).toBe(mod.BACKOFF_POLL_INTERVAL_MS);
+  });
+
+  it("resets the interval to 5s on the first successful poll after a streak", async () => {
+    mocks.getEvents.mockRejectedValue(new Error("RPC down"));
+    await mod.startEventListenerService();
+
+    await mod.pollEvents();
+    await mod.pollEvents();
+    await mod.pollEvents();
+    expect(lastIntervalDelay(setIntervalSpy)).toBe(mod.BACKOFF_POLL_INTERVAL_MS);
+
+    // Recovery.
+    mocks.getEvents.mockResolvedValue({ events: [] });
+    await mod.pollEvents();
+
+    expect(lastIntervalDelay(setIntervalSpy)).toBe(mod.NORMAL_POLL_INTERVAL_MS);
+    expect(mod.getServiceHealth().status).toBe("healthy");
+    expect(mod.getServiceHealth().consecutiveErrors).toBe(0);
+    expect(mod.getServiceHealth().lastSuccessfulPoll).not.toBeNull();
+  });
+
+  it("reports 'stopped' before start and after stop", async () => {
+    expect(mod.getServiceHealth().status).toBe("stopped");
+
+    mocks.getEvents.mockResolvedValue({ events: [] });
+    await mod.startEventListenerService();
+    expect(mod.getServiceHealth().status).toBe("healthy");
+
+    mod.stopEventListenerService();
+    expect(mod.getServiceHealth().status).toBe("stopped");
+  });
+});
+
+describe("EventListenerService - catch-up window cap", () => {
+  it("caps a far-behind start ledger to MAX_CATCHUP_LEDGERS behind tip", () => {
+    const tip = 500_000;
+    const capped = mod.capCatchUpWindow(tip, tip - 50_000);
+    expect(capped).toBe(tip - mod.MAX_CATCHUP_LEDGERS);
+  });
+
+  it("leaves a recent start ledger unchanged", () => {
+    const tip = 500_000;
+    const desired = tip - 100;
+    expect(mod.capCatchUpWindow(tip, desired)).toBe(desired);
+  });
+});

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -2,6 +2,7 @@ import { Router, type NextFunction, type Response } from "express";
 import { getEnvDiagnostics } from "../config/env.js";
 import { getDataSource } from "../services/database.js";
 import { checkSorobanReachability } from "../services/stellar.js";
+import { getServiceHealth } from "../services/EventListenerService.js";
 
 export const healthRouter = Router();
 
@@ -151,5 +152,15 @@ async function handleReadiness(_req: unknown, res: Response, next: NextFunction)
     return;
   }
 
-  res.json({ status: "ready", components });
+  // Surface the background event listener's health. A degraded listener (e.g.
+  // during a Soroban RPC outage with active back-off) does not make the API
+  // unready for reads, so this is reported informationally rather than failing
+  // the readiness probe.
+  const eventListener = getServiceHealth();
+
+  res.json({
+    status: "ready",
+    version: SERVICE_VERSION,
+    components: { ...components, eventListener },
+  });
 }

--- a/backend/src/services/EventListenerService.ts
+++ b/backend/src/services/EventListenerService.ts
@@ -6,10 +6,70 @@ import { scValToNative } from "@stellar/stellar-sdk";
 import { fetchProjectById } from "./splits.service.js";
 import { publishSseEvent } from "./SseEventBus.js";
 
+// Polling cadence. Under normal operation we poll every 5s. After a streak of
+// consecutive RPC failures we back off to 30s to avoid hammering an RPC that is
+// down, then return to the normal cadence on the first successful poll.
+export const NORMAL_POLL_INTERVAL_MS = 5_000;
+export const BACKOFF_POLL_INTERVAL_MS = 30_000;
+export const ERROR_THRESHOLD = 3;
+
+// Catch-up safety. If, on (re)start, the ledger we would resume from is more
+// than this many ledgers behind the chain tip, we skip ahead so a prolonged
+// outage cannot flood the RPC with thousands of catch-up requests.
+export const MAX_CATCHUP_LEDGERS = 10_000;
+const STARTUP_LOOKBACK_LEDGERS = 100;
+
+export type ServiceStatus = "stopped" | "healthy" | "degraded";
+
 let pollInterval: NodeJS.Timeout | null = null;
 let isPolling = false;
 let startLedger: number | null = null;
 let cursor: string | null = null;
+
+// Resilience state.
+let consecutiveErrors = 0;
+let lastSuccessfulPoll: string | null = null;
+let currentPollDelayMs = NORMAL_POLL_INTERVAL_MS;
+
+/**
+ * (Re)arms the polling timer at the requested cadence. Idempotent: if the timer
+ * is already running at `delayMs`, it is left untouched so we don't churn timers
+ * on every poll.
+ */
+function schedulePolling(delayMs: number): void {
+  if (pollInterval && currentPollDelayMs === delayMs) {
+    return;
+  }
+
+  if (pollInterval) {
+    clearInterval(pollInterval);
+  }
+
+  currentPollDelayMs = delayMs;
+  pollInterval = setInterval(() => {
+    void pollEvents();
+  }, delayMs);
+}
+
+/**
+ * Caps how far back polling may resume. If `desiredStartLedger` is more than
+ * {@link MAX_CATCHUP_LEDGERS} behind `latestLedger`, returns a ledger that is
+ * exactly `MAX_CATCHUP_LEDGERS` behind the tip and logs a warning. Otherwise
+ * returns `desiredStartLedger` unchanged.
+ */
+export function capCatchUpWindow(
+  latestLedger: number,
+  desiredStartLedger: number
+): number {
+  if (latestLedger - desiredStartLedger > MAX_CATCHUP_LEDGERS) {
+    const capped = latestLedger - MAX_CATCHUP_LEDGERS;
+    logger.warn(
+      `EventListenerService: requested start ledger ${desiredStartLedger} is more than ${MAX_CATCHUP_LEDGERS} ledgers behind tip ${latestLedger}; advancing to ${capped} to bound catch-up.`
+    );
+    return capped;
+  }
+  return desiredStartLedger;
+}
 
 export async function startEventListenerService() {
   if (pollInterval) {
@@ -19,14 +79,16 @@ export async function startEventListenerService() {
 
   logger.info("Starting EventListenerService background worker...");
 
+  consecutiveErrors = 0;
+
   try {
     const server = getStellarRpcServer();
-    const latestLedger = await executeWithRetry(() =>
-      server.getLatestLedger()
-    );
+    const latestLedger = await executeWithRetry(() => server.getLatestLedger());
 
-    // Start polling from 100 ledgers back to cover restart gaps
-    startLedger = Math.max(1, latestLedger.sequence - 100);
+    // Start polling from a small lookback to cover restart gaps, but never more
+    // than MAX_CATCHUP_LEDGERS behind the tip.
+    const desiredStart = Math.max(1, latestLedger.sequence - STARTUP_LOOKBACK_LEDGERS);
+    startLedger = capCatchUpWindow(latestLedger.sequence, desiredStart);
 
     logger.info(
       `Initialized EventListenerService to start polling from ledger: ${startLedger}`
@@ -38,25 +100,77 @@ export async function startEventListenerService() {
     );
   }
 
-  pollInterval = setInterval(() => {
-    void pollEvents();
-  }, 5000);
+  schedulePolling(NORMAL_POLL_INTERVAL_MS);
 }
 
 export function stopEventListenerService() {
   if (pollInterval) {
     clearInterval(pollInterval);
     pollInterval = null;
+    currentPollDelayMs = NORMAL_POLL_INTERVAL_MS;
+    consecutiveErrors = 0;
     logger.info("EventListenerService background worker stopped cleanly.");
   }
 }
 
-export function getServiceHealth() {
-  return {
-    running: pollInterval !== null,
-    isPolling,
-    cursor,
-  };
+/**
+ * Health snapshot consumed by the readiness health check.
+ *
+ * - `status`: `stopped` (not running), `healthy` (running, no failure streak),
+ *   or `degraded` (running but in an RPC failure back-off).
+ * - `lastSuccessfulPoll`: ISO timestamp of the last poll that completed without
+ *   error, or `null` if none yet.
+ * - `consecutiveErrors`: number of consecutive failing polls.
+ */
+export function getServiceHealth(): {
+  status: ServiceStatus;
+  lastSuccessfulPoll: string | null;
+  consecutiveErrors: number;
+} {
+  let status: ServiceStatus;
+  if (!pollInterval) {
+    status = "stopped";
+  } else if (consecutiveErrors >= ERROR_THRESHOLD) {
+    status = "degraded";
+  } else {
+    status = "healthy";
+  }
+
+  return { status, lastSuccessfulPoll, consecutiveErrors };
+}
+
+/** Records a failed poll and backs off the cadence once the threshold is hit. */
+function recordPollFailure(error: unknown): void {
+  consecutiveErrors += 1;
+  logger.error("Error occurred in background Soroban event poll", {
+    error,
+    consecutiveErrors,
+  });
+
+  if (consecutiveErrors >= ERROR_THRESHOLD && currentPollDelayMs !== BACKOFF_POLL_INTERVAL_MS) {
+    logger.warn(
+      `EventListenerService: ${consecutiveErrors} consecutive poll failures; backing off poll interval to ${BACKOFF_POLL_INTERVAL_MS}ms.`
+    );
+    schedulePolling(BACKOFF_POLL_INTERVAL_MS);
+  }
+}
+
+/** Records a successful poll and resets the cadence after a failure streak. */
+function recordPollSuccess(): void {
+  if (consecutiveErrors > 0) {
+    logger.info(
+      `EventListenerService: recovered after ${consecutiveErrors} consecutive failure(s).`
+    );
+  }
+  consecutiveErrors = 0;
+  lastSuccessfulPoll = new Date().toISOString();
+
+  if (currentPollDelayMs !== NORMAL_POLL_INTERVAL_MS) {
+    logger.info(
+      `EventListenerService: resetting poll interval to ${NORMAL_POLL_INTERVAL_MS}ms after recovery.`
+    );
+    schedulePolling(NORMAL_POLL_INTERVAL_MS);
+  }
 }
 
 export async function pollEvents() {
@@ -83,9 +197,7 @@ export async function pollEvents() {
       ? { filters, startLedger, limit: 100 }
       : { filters, cursor: "", limit: 100 };
 
-    const response = await executeWithRetry(() =>
-      server.getEvents(filterOptions)
-    );
+    const response = await executeWithRetry(() => server.getEvents(filterOptions));
 
     if (response?.events?.length) {
       const records: TransactionRecord[] = [];
@@ -100,52 +212,36 @@ export async function pollEvents() {
             }
           });
 
-          // Check for `payment_sent` events
-          if (topics[0] === "payment_sent") {
-            const projectId = topics[1] || "";
-            const valueData = scValToNative(event.value) as [string, string | number | bigint];
-            const recipient = valueData[0];
-            const amount = String(valueData[1]);
-            const txHash = event.txHash;
-            const timestamp = Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000);
+          // Only `payment_sent` events are indexed as transaction records.
+          if (topics[0] !== "payment_sent") {
+            continue;
+          }
 
-            // Verify if transaction is already indexed. The database also enforces
-            // uniqueness on txHash via a unique index, but this application-layer
-            // check avoids duplicate save attempts during event polling.
-            const existing = await repo.findOneBy({ txHash });
-            if (!existing) {
-              // Retrieve project to get its token address
-              let token = "Native";
-              try {
-                const project = await fetchProjectById(projectId);
-                if (project && typeof project === "object" && "token" in project) {
-                  token = String(project.token);
-                }
-              } catch (err) {
-                logger.warn(`Could not resolve token address for project ${projectId}. Using fallback.`, { err });
-              }
+          const projectId = topics[1] || "";
+          const valueData = scValToNative(event.value) as [
+            string,
+            string | number | bigint
+          ];
+          const recipient = valueData[0];
+          const amount = String(valueData[1]);
+          const txHash = event.txHash;
+          const timestamp = Math.floor(
+            new Date(event.ledgerClosedAt).getTime() / 1000
+          );
 
-              const record = repo.create({
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                txHash,
-                status: "completed"
-              });
+          // Skip already-indexed transactions. The DB also enforces uniqueness
+          // on txHash, but this avoids redundant work during polling.
+          const existing = await repo.findOneBy({ txHash });
+          if (existing) {
+            continue;
+          }
 
-              await repo.save(record);
-              logger.info(`Synced payout event to database: project=${projectId}, recipient=${recipient}, amount=${amount}, tx=${txHash}`);
-              publishSseEvent(txHash, {
-                txHash,
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                status: "completed"
-              });
+          // Resolve the project's token address; fall back to "Native".
+          let token = "Native";
+          try {
+            const project = await fetchProjectById(projectId);
+            if (project && typeof project === "object" && "token" in project) {
+              token = String(project.token);
             }
           } catch (err) {
             logger.warn(
@@ -165,6 +261,16 @@ export async function pollEvents() {
               status: "completed",
             })
           );
+
+          publishSseEvent(txHash, {
+            txHash,
+            roundId: projectId,
+            recipient,
+            amount,
+            token,
+            timestamp,
+            status: "completed",
+          });
         } catch (eventError) {
           logger.error("Error processing polled Soroban event", {
             event,
@@ -188,10 +294,10 @@ export async function pollEvents() {
         cursor = response.cursor;
       }
     }
+
+    recordPollSuccess();
   } catch (error) {
-    logger.error("Error occurred in background Soroban event poll", {
-      error,
-    });
+    recordPollFailure(error);
   } finally {
     isPolling = false;
   }


### PR DESCRIPTION
closes #627 

When server.getEvents() fails, the listener kept polling at 5s and, after a prolonged outage, could resume from a startLedger thousands of ledgers behind, flooding the RPC with catch-up requests.

- Back-off: track consecutive errors; after 3 in a row, reschedule the poll interval to 30s (clearInterval + setInterval). On the first successful poll after a failure streak, reset to 5s.
- Catch-up cap: capCatchUpWindow() advances the resume point to latestLedger - 10_000 (with a warning) if it would otherwise be more than 10_000 ledgers behind the tip; applied on (re)start.
- getServiceHealth() now returns { status, lastSuccessfulPoll, consecutiveErrors } (status: stopped | healthy | degraded) and is surfaced in the readiness probe (health.ts) as an informational `eventListener` component.

Also fixes a pre-existing syntax error in pollEvents (a dangling `catch` with no `try`, plus out-of-scope/duplicate record handling) that prevented the backend from compiling at all; the event-processing loop is restructured cleanly.

Tests: src/__tests__/event-listener-backoff.test.ts (6 cases) covering the back-off, recovery, health states, and catch-up cap. tsc + eslint clean on the changed files.
