### PR TITLE
feat(backend): SSE EventBus + /events/transactions/:txHash stream (#618)

### DIFF
--- a/backend/src/__tests__/events-transactions-sse.test.ts
+++ b/backend/src/__tests__/events-transactions-sse.test.ts
@@ -1,0 +1,134 @@
+/**
+ * SSE transaction stream integration tests (Issue #618)
+ *
+ * Verifies GET /events/transactions/:txHash:
+ *  - a subscriber receives a JSON event when the matching transaction is
+ *    confirmed (emitted on the shared EventBus),
+ *  - non-matching transactions are not delivered,
+ *  - the bus listener is cleaned up on client disconnect.
+ *
+ * Uses raw http (like events.test.ts) to avoid pulling in an EventSource
+ * polyfill dependency; it exercises the same SSE contract a browser would.
+ */
+
+import http from "http";
+import type { Socket } from "net";
+import { AddressInfo } from "net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let server: http.Server;
+let baseUrl: string;
+const openSockets = new Set<Socket>();
+
+let getEventBus: typeof import("../services/EventBus.js").getEventBus;
+let TRANSACTION_CONFIRMED: typeof import("../services/EventBus.js").TRANSACTION_CONFIRMED;
+
+beforeAll(async () => {
+  const { app } = await import("../index.js");
+  ({ getEventBus, TRANSACTION_CONFIRMED } = await import("../services/EventBus.js"));
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+      resolve();
+    });
+    server.on("connection", (socket) => {
+      openSockets.add(socket);
+      socket.on("close", () => openSockets.delete(socket));
+    });
+  });
+});
+
+afterAll(async () => {
+  openSockets.forEach((socket) => socket.destroy());
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+/** Opens an SSE connection and resolves with the response + the request handle. */
+function openStream(path: string): Promise<{ res: http.IncomingMessage; req: http.ClientRequest }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`${baseUrl}${path}`, (res) => resolve({ res, req }));
+    req.on("error", reject);
+  });
+}
+
+/** Parses the `data:` line out of the first complete SSE message in a buffer. */
+function parseFirstSseData(buffer: string): unknown | null {
+  const match = buffer.match(/data: (.*)\n\n/);
+  return match ? JSON.parse(match[1]) : null;
+}
+
+describe("GET /events/transactions/:txHash (SSE)", () => {
+  it("opens an SSE stream with the correct headers", async () => {
+    const { res, req } = await openStream("/events/transactions/tx-headers");
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/event-stream/);
+    expect(res.headers["connection"]).toMatch(/keep-alive/i);
+    req.destroy();
+  });
+
+  it("delivers a JSON event when the matching transaction is confirmed", async () => {
+    const txHash = "tx-match-123";
+    const record = {
+      txHash,
+      roundId: "proj-1",
+      recipient: "GREC...",
+      amount: "1000",
+      token: "Native",
+      timestamp: 1_700_000_000,
+      status: "completed",
+    };
+
+    const { res, req } = await openStream(`/events/transactions/${txHash}`);
+
+    const received = new Promise<unknown>((resolve) => {
+      let buffer = "";
+      res.on("data", (chunk) => {
+        buffer += chunk.toString();
+        const data = parseFirstSseData(buffer);
+        if (data) resolve(data);
+      });
+    });
+
+    // Give the route a tick to register its bus listener, then emit.
+    await new Promise((r) => setTimeout(r, 50));
+    getEventBus().emit(TRANSACTION_CONFIRMED, record);
+
+    const data = (await received) as { txHash: string; status: string };
+    expect(data.txHash).toBe(txHash);
+    expect(data.status).toBe("completed");
+    req.destroy();
+  });
+
+  it("does not deliver events for a different txHash", async () => {
+    const { res, req } = await openStream("/events/transactions/tx-mine");
+
+    let gotData = false;
+    res.on("data", (chunk) => {
+      if (/data: /.test(chunk.toString())) gotData = true;
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    getEventBus().emit(TRANSACTION_CONFIRMED, { txHash: "tx-someone-else" });
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(gotData).toBe(false);
+    req.destroy();
+  });
+
+  it("cleans up the bus listener on client disconnect", async () => {
+    const bus = getEventBus();
+
+    const { req } = await openStream("/events/transactions/tx-cleanup");
+    await new Promise((r) => setTimeout(r, 50));
+    // Count with this subscription active (relative to any other live streams).
+    const connected = bus.listenerCount(TRANSACTION_CONFIRMED);
+
+    req.destroy();
+    // Allow the server to observe the closed connection.
+    await new Promise((r) => setTimeout(r, 200));
+    expect(bus.listenerCount(TRANSACTION_CONFIRMED)).toBe(connected - 1);
+  });
+});

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -1,7 +1,12 @@
 import { Router, Request, Response } from "express";
 import { getSseEventBus, getSseEventName } from "../services/SseEventBus.js";
+import { getEventBus, TRANSACTION_CONFIRMED } from "../services/EventBus.js";
 import { logger } from "../services/logger.js";
 import { AppError, ErrorCode, ErrorType } from "../lib/errors.js";
+
+// Heartbeat cadence for the path-based transaction stream. A comment line every
+// 15s keeps intermediary proxies from closing an otherwise-idle connection.
+const HEARTBEAT_INTERVAL_MS = 15_000;
 
 export const eventsRouter = Router();
 
@@ -111,4 +116,61 @@ async function handleEventStream(req: Request, res: Response) {
   logger.info("SSE subscription opened", { txHash, requestId, currentCount: currentCount + 1 });
 }
 
+/**
+ * SSE endpoint (Issue #618): GET /events/transactions/:txHash
+ *
+ * Holds the response open and streams the matching `transaction:confirmed`
+ * event (emitted by EventListenerService once the record is saved) as a JSON
+ * SSE message. The bus listener is removed and the heartbeat cleared when the
+ * client disconnects.
+ */
+function handleTransactionStream(req: Request, res: Response) {
+  const txHash = String(req.params.txHash ?? "").trim();
+  const requestId = res.locals.requestId as string | undefined;
+
+  if (!txHash) {
+    throw new AppError(
+      ErrorType.VALIDATION,
+      ErrorCode.VALIDATION_ERROR,
+      "Path parameter txHash is required for /events/transactions subscriptions."
+    );
+  }
+
+  createSseHeaders(res);
+
+  const bus = getEventBus();
+  const listener = (record: unknown) => {
+    if (
+      record &&
+      typeof record === "object" &&
+      (record as { txHash?: unknown }).txHash === txHash
+    ) {
+      try {
+        sendSseEvent(res, "transaction:confirmed", record);
+      } catch (writeError) {
+        logger.warn("Failed to send transaction SSE payload", {
+          txHash,
+          requestId,
+          error: writeError,
+        });
+      }
+    }
+  };
+
+  bus.on(TRANSACTION_CONFIRMED, listener);
+
+  const heartbeat = setInterval(() => {
+    res.write(": heartbeat\n\n");
+  }, HEARTBEAT_INTERVAL_MS);
+
+  req.on("close", () => {
+    bus.removeListener(TRANSACTION_CONFIRMED, listener);
+    clearInterval(heartbeat);
+    logger.info("Transaction SSE client disconnected", { txHash, requestId });
+  });
+
+  logger.info("Transaction SSE subscription opened", { txHash, requestId });
+}
+
 eventsRouter.get("/", handleEventStream);
+eventsRouter.get("/transactions/:txHash", handleTransactionStream);

--- a/backend/src/services/EventBus.ts
+++ b/backend/src/services/EventBus.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from "events";
+
+/**
+ * Application-wide event bus (Issue #618).
+ *
+ * A single shared {@link EventEmitter} that backend services use to broadcast
+ * named domain events to in-process consumers (e.g. the SSE routes). This is
+ * deliberately transport-agnostic: producers emit, the SSE layer fans out to
+ * connected clients.
+ *
+ * Named events:
+ * - {@link TRANSACTION_CONFIRMED} — payload: a saved `TransactionRecord`.
+ */
+
+/** Emitted after a transaction record has been persisted. */
+export const TRANSACTION_CONFIRMED = "transaction:confirmed";
+
+const eventBus = new EventEmitter();
+// SSE means one listener per connected client; there is no meaningful upper
+// bound, so disable the default max-listeners warning.
+eventBus.setMaxListeners(0);
+
+/** Returns the process-wide singleton event bus. */
+export function getEventBus(): EventEmitter {
+  return eventBus;
+}

--- a/backend/src/services/EventListenerService.ts
+++ b/backend/src/services/EventListenerService.ts
@@ -5,6 +5,7 @@ import { logger } from "./logger.js";
 import { scValToNative } from "@stellar/stellar-sdk";
 import { fetchProjectById } from "./splits.service.js";
 import { publishSseEvent } from "./SseEventBus.js";
+import { getEventBus, TRANSACTION_CONFIRMED } from "./EventBus.js";
 
 let pollInterval: NodeJS.Timeout | null = null;
 let isPolling = false;
@@ -100,52 +101,36 @@ export async function pollEvents() {
             }
           });
 
-          // Check for `payment_sent` events
-          if (topics[0] === "payment_sent") {
-            const projectId = topics[1] || "";
-            const valueData = scValToNative(event.value) as [string, string | number | bigint];
-            const recipient = valueData[0];
-            const amount = String(valueData[1]);
-            const txHash = event.txHash;
-            const timestamp = Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000);
+          // Only `payment_sent` events are indexed as transaction records.
+          if (topics[0] !== "payment_sent") {
+            continue;
+          }
 
-            // Verify if transaction is already indexed. The database also enforces
-            // uniqueness on txHash via a unique index, but this application-layer
-            // check avoids duplicate save attempts during event polling.
-            const existing = await repo.findOneBy({ txHash });
-            if (!existing) {
-              // Retrieve project to get its token address
-              let token = "Native";
-              try {
-                const project = await fetchProjectById(projectId);
-                if (project && typeof project === "object" && "token" in project) {
-                  token = String(project.token);
-                }
-              } catch (err) {
-                logger.warn(`Could not resolve token address for project ${projectId}. Using fallback.`, { err });
-              }
+          const projectId = topics[1] || "";
+          const valueData = scValToNative(event.value) as [
+            string,
+            string | number | bigint
+          ];
+          const recipient = valueData[0];
+          const amount = String(valueData[1]);
+          const txHash = event.txHash;
+          const timestamp = Math.floor(
+            new Date(event.ledgerClosedAt).getTime() / 1000
+          );
 
-              const record = repo.create({
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                txHash,
-                status: "completed"
-              });
+          // Skip already-indexed transactions. The DB also enforces uniqueness
+          // on txHash, but this avoids redundant work during polling.
+          const existing = await repo.findOneBy({ txHash });
+          if (existing) {
+            continue;
+          }
 
-              await repo.save(record);
-              logger.info(`Synced payout event to database: project=${projectId}, recipient=${recipient}, amount=${amount}, tx=${txHash}`);
-              publishSseEvent(txHash, {
-                txHash,
-                roundId: projectId,
-                recipient,
-                amount,
-                token,
-                timestamp,
-                status: "completed"
-              });
+          // Resolve the project's token address; fall back to "Native".
+          let token = "Native";
+          try {
+            const project = await fetchProjectById(projectId);
+            if (project && typeof project === "object" && "token" in project) {
+              token = String(project.token);
             }
           } catch (err) {
             logger.warn(
@@ -182,6 +167,21 @@ export async function pollEvents() {
         logger.info(
           `Upserted ${records.length} transaction record(s) from current event batch.`
         );
+
+        // Real-time push: notify the generic event bus (Issue #618) and the
+        // txHash-keyed SSE bus so connected clients are updated immediately.
+        for (const record of records) {
+          getEventBus().emit(TRANSACTION_CONFIRMED, record);
+          publishSseEvent(record.txHash, {
+            txHash: record.txHash,
+            roundId: record.roundId,
+            recipient: record.recipient,
+            amount: record.amount,
+            token: record.token,
+            timestamp: record.timestamp,
+            status: record.status,
+          });
+        }
       }
 
       if (response.cursor) {


### PR DESCRIPTION
Adds a transport-agnostic broadcast channel and a path-based SSE endpoint so clients get real-time transaction confirmations instead of polling.

- services/EventBus.ts: process-wide singleton EventEmitter with the named `transaction:confirmed` event.
- EventListenerService.ts: after persisting a TransactionRecord, emit `transaction:confirmed` on the bus (alongside the existing txHash SSE publish). Also restructures the event-processing loop, which had a dangling `catch` (no matching `try`) plus out-of-scope/duplicate record handling that prevented the backend from compiling.
- routes/events.ts: new GET /events/transactions/:txHash SSE handler — holds the response open, streams the matching `transaction:confirmed` record as JSON, sends a heartbeat comment every 15s (Connection: keep-alive already set), and removes the bus listener + clears the heartbeat on req close.
- index.ts already mounts eventsRouter at /events, so the new route is live with no registration change.

Test: src/__tests__/events-transactions-sse.test.ts (4 cases) — headers, delivery of a matching confirmation, no cross-txHash delivery, and listener cleanup on disconnect. Uses raw http (no EventSource polyfill dependency) to exercise the same SSE contract. tsc + eslint clean on changed files.


Closes #618 
