### PR TITLE
feat: add human-readable messages to SplitError (#673)

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -142,8 +142,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -327,6 +329,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 name = "dx_tooling"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
  "soroban-sdk",
 ]
 
@@ -1207,6 +1212,7 @@ dependencies = [
 name = "splitnaira-contracts"
 version = "0.1.0"
 dependencies = [
+ "arbitrary",
  "derive_arbitrary",
  "dx_tooling",
  "soroban-sdk",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -2,9 +2,15 @@
 name = "splitnaira-contracts"
 version = "0.1.0"
 edition = "2021"
-description = "Soroban smart contracts for SplitNaira â€” royalty splitting on Stellar"
+description = "Soroban smart contracts for SplitNaira — royalty splitting on Stellar"
 license = "MIT"
 repository = "https://github.com/Split-Naira/SplitNaira"
+
+[workspace]
+members = [
+    ".",
+    "dx_tooling"
+]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -25,7 +31,8 @@ testutils = ["soroban-sdk/testutils"]
 soroban-sdk = { version = "=20.5.0" }
 
 [dev-dependencies]
-derive_arbitrary = "1.3.2"
+arbitrary = { version = "=1.3.2", features = ["derive"] }
+derive_arbitrary = "=1.3.2"
 soroban-sdk = { version = "=20.5.0", features = ["testutils"] }
 dx_tooling = { path = "dx_tooling" }
 
@@ -42,4 +49,3 @@ lto = true
 [profile.release-with-logs]
 inherits = "release"
 debug-assertions = true
-

--- a/contracts/dx_tooling/Cargo.toml
+++ b/contracts/dx_tooling/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 soroban-sdk = "20.0.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }

--- a/contracts/dx_tooling/src/lib.rs
+++ b/contracts/dx_tooling/src/lib.rs
@@ -1,5 +1,3 @@
-#![no_std]
-
 pub mod compiler;
 pub mod simulator;
 pub mod deployer;

--- a/contracts/errors.rs
+++ b/contracts/errors.rs
@@ -121,4 +121,31 @@ impl SplitError {
                 | SplitError::InsufficientUnallocated
         )
     }
+
+    /// Returns a human-readable description for off-chain tooling and debugging.
+    pub fn to_message(&self) -> &'static str {
+        match self {
+            SplitError::ProjectExists => "A project with the specified ID already exists.",
+            SplitError::NotFound => "The requested project could not be found.",
+            SplitError::AlreadyLocked => "The project is permanently locked.",
+            SplitError::ProjectLocked => "The project is locked and cannot be modified.",
+            SplitError::Unauthorized => "Caller is not authorized to perform this action.",
+            SplitError::NotACollaborator => "Address is not a registered collaborator.",
+            SplitError::InvalidSplit => "Collaborator basis points must total exactly 10,000.",
+            SplitError::TooFewCollaborators => "At least two collaborators are required.",
+            SplitError::ZeroShare => "Collaborator share cannot be zero.",
+            SplitError::DuplicateCollaborator => "Duplicate collaborator address detected.",
+            SplitError::InvalidAmount => "Deposit or transfer amount is invalid.",
+            SplitError::InvalidRecipient => "Recipient address is invalid.",
+            SplitError::TooManyCollaborators => "Maximum collaborator limit exceeded.",
+            SplitError::NoBalance => "Project has no balance available for distribution.",
+            SplitError::TokenNotAllowed => "Token is not included in the configured allowlist.",
+            SplitError::InsufficientUnallocated => "Requested withdrawal exceeds available unallocated funds.",
+            SplitError::AdminNotSet => "Contract administrator has not been configured.",
+            SplitError::DistributionsPaused => "Distributions have been paused by the administrator.",
+            SplitError::AccountingDiscrepancy => "Cached accounted balance exceeds the contract's actual token balance.",
+            SplitError::InvalidMaxCollaborators => "Admin-supplied capacity limit is outside the permitted range.",
+            SplitError::ArithmeticOverflow => "An arithmetic operation overflowed.",
+        }
+    }
 }

--- a/contracts/reliability_tests.rs
+++ b/contracts/reliability_tests.rs
@@ -41,7 +41,7 @@ fn two_collabs(env: &Env) -> Vec<Collaborator> {
 /// Creates a project with a registered token and returns the (client, owner, token).
 /// Token allowlist is bypassed by using register_stellar_asset_contract which
 /// Soroban testutils accept without an admin allowlist entry.
-fn setup_project(env: &Env, project_id: &Symbol) -> (SplitNairaContractClient, Address, Address) {
+fn setup_project<'a>(env: &'a Env, project_id: &Symbol) -> (SplitNairaContractClient<'a>, Address, Address) {
     let (client, _) = make_client(env);
     let token_admin = Address::generate(env);
     let token = env.register_stellar_asset_contract(token_admin);

--- a/contracts/tests.rs
+++ b/contracts/tests.rs
@@ -1565,10 +1565,27 @@ fn test_basis_points_invariant_table() {
 
         match expected_err {
             None => assert_eq!(result, Ok(Ok(())), "case {} expected success but got {:?}", i, result),
-            Some(err) => assert_eq!(result, Err(Ok(*err)), "case {} expected {:?} but got {:?}", i, err, result),
+            Some(err) => {
+                let msg = err.to_message();
+                match result {
+                    Err(Ok(actual_err)) => {
+                        assert_eq!(
+                            actual_err.to_message(),
+                            msg,
+                            "case {} failed. Expected message: \"{}\", got: \"{}\"",
+                            i,
+                            msg,
+                            actual_err.to_message()
+                        );
+                    }
+                    other => {
+                        panic!("case {} failed. Expected error with message: \"{}\", but got: {:?}", i, msg, other);
+                    }
+                }
+            }
         }
     }
-}
+} 
 
 #[test]
 fn test_list_projects_bounds() {


### PR DESCRIPTION
## Summary
Adds a `to_message()` method to the `SplitError` enum to provide human-readable error descriptions. This improves the developer experience for off-chain tooling and makes test output much easier to read when failures occur.

Closes #673

## Changes
- Added a `to_message(&self) -> &'static str` method mapping every `SplitError` variant to a descriptive string in `contracts/errors.rs`.
- Updated testing tables in `contracts/tests.rs` to validate against these new human-readable messages instead of raw variants.
- Fixed workspace compilation issues in the `dx_tooling` crate (removed `#![no_std]` and added missing `serde`/`chrono` dependencies).
- Resolved minor Rust compiler lifetime (`<'a>`) and moved-value issues in `contracts/reliability_tests.rs` and `contracts/tests.rs`.

## Testing
- [x] Unit tests added / updated
- [ ] Integration / E2E tests pass
- [x] Manually verified on local stack (all `cargo test` suites pass cleanly)

## Deploy Impact

### Risk level
- [ ] Low — docs/config only, no logic change
- [x] Medium — logic change, backward-compatible
- [ ] High — breaking change, contract change, or schema migration

### Contract changes
- [x] No contract changes (The on-chain error codes remain unchanged u32 values; the new method is purely for off-chain Rust API and tests).
- [ ] Contract changes included — migration plan: 

### Database migrations
- [x] No migrations
- [ ] Migration included — rollback script: 

### Environment variables
- [x] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
Standard `git revert`. No state migrations, database schema changes, or Wasm interface breaking changes were introduced.

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.