### PR TITLE
Contract hardening PR #4: dup-address validation, CI permissions audit, OpenAPI examples, i18n key parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci --no-audit --no-fund
+      - run: npm run check:i18n -w frontend
       - run: npm run lint -w frontend
       - run: npm run build -w frontend
       - run: npm run test -w frontend

--- a/.github/workflows/contract-testnet-deploy.yml
+++ b/.github/workflows/contract-testnet-deploy.yml
@@ -9,8 +9,10 @@ on:
       - ".github/workflows/contract-testnet-deploy.yml"
   workflow_dispatch:
 
+# Read-only default; the deploy-testnet job elevates to contents: write
+# because it commits the redeployed contract id back to the repo.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: contract-testnet-deploy
@@ -20,6 +22,10 @@ jobs:
   deploy-testnet:
     runs-on: ubuntu-latest
     if: github.actor != 'github-actions[bot]'
+    # Exception: needs to commit + push contracts/deployments.json and the
+    # generated contract config files after a successful testnet deploy.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Verify contract data integrity
         run: npm run verify:data-integrity
 
+      - name: Verify i18n message key parity
+        run: npm run check:i18n -w frontend
+
       - name: Run Lint
         run: npm run lint -w frontend
 

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Verify i18n message key parity
+        run: npm run check:i18n -w frontend
+
       - name: Lint
         run: npm run lint -w frontend
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,17 @@ on:
     tags:
       - 'v*.*.*'
 
+# Read-only default; the create-release job elevates to contents: write
+# because it publishes a draft GitHub Release for the pushed tag.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    # Exception: ncipollo/release-action needs write access to create the release.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/smoke-testnet.yml
+++ b/.github/workflows/smoke-testnet.yml
@@ -21,6 +21,11 @@ on:
         default: "false"
         type: boolean
 
+# Read-only: only checks out the repo and calls the live testnet contract
+# with a secret key; never pushes to the repo or GitHub API.
+permissions:
+  contents: read
+
 jobs:
   smoke-test:
     name: Smoke test on Testnet

--- a/backend/src/__tests__/openapi.test.ts
+++ b/backend/src/__tests__/openapi.test.ts
@@ -1,6 +1,13 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
 import { describe, it, expect } from "vitest";
 import SwaggerParser from "@apidevtools/swagger-parser";
+import * as yaml from "yaml";
 import { generateOpenApi } from "../openapi.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const committedSpecPath = join(__dirname, "..", "..", "..", "docs", "openapi.yaml");
 
 describe("OpenAPI specification", () => {
   it("generates a valid OpenAPI document without $ref errors", async () => {
@@ -16,5 +23,11 @@ describe("OpenAPI specification", () => {
     }
 
     await expect(SwaggerParser.validate(spec)).resolves.toBeDefined();
+  });
+
+  it("matches the committed docs/openapi.yaml (run `cd backend && npm run generate:openapi` if this fails)", () => {
+    const generated = yaml.stringify(generateOpenApi());
+    const committed = readFileSync(committedSpecPath, "utf8");
+    expect(generated).toBe(committed);
   });
 });

--- a/backend/src/openapi.ts
+++ b/backend/src/openapi.ts
@@ -43,22 +43,72 @@ import {
 
 const registry = new OpenAPIRegistry();
 
+// ─── Example fixtures ──────────────────────────────────────────────────────────
+//
+// Realistic (but non-custodial) Stellar addresses used across request/response
+// examples below. Keep the shapes here aligned with the fixtures used in
+// backend/src/__tests__/e2e-happy-path.test.ts and events*.test.ts so the docs
+// don't drift from what the test suite actually exercises.
+
+const EXAMPLE_OWNER = "GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT";
+const EXAMPLE_COLLAB_A = "GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV";
+const EXAMPLE_COLLAB_B = "GBG234UA6RBPDD5K6FHMQXHUXB5ALOENQGH24Y3W4ERX2YJNQ4MK4V25";
+const EXAMPLE_ADMIN = "GCJIQR7K2ZNIBXKFYHC6YMGD7CX46X3LAUBZAMQSMFB3XPHDY6YAT5GC";
+const EXAMPLE_TOKEN = "CDOVDY3MZDG7PHCGVP7EP2EKQ2ENV26DZW6FKLBRN42LOGIZGXZV3WX5";
+const EXAMPLE_CONTRACT_ID = "CAGR5U5IBEPFVJDZPZUXXNCPXAHNZ6TWVIUTI5RLRH3SZSU4O2VXDOPF";
+const EXAMPLE_PROJECT_ID = "afrobeats_001";
+const EXAMPLE_TX_HASH = "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc";
+const EXAMPLE_REQUEST_ID = "b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d";
+
+// Mirrors projectIdParamSchema's constraints (see schemas/splits.ts). Built
+// locally rather than calling `.openapi()` on the imported schema directly:
+// ESM hoists that import ahead of the `extendZodWithOpenApi(z)` call above,
+// so the imported instance never picks up the `.openapi()` prototype method.
+const exampleProjectIdParam = z
+  .string()
+  .min(1)
+  .max(32)
+  .regex(/^[a-zA-Z0-9_]+$/)
+  .openapi({ example: EXAMPLE_PROJECT_ID, description: "Project ID" });
+
+function xdrExample(operation: string) {
+  return {
+    xdr: "AAAAAgAAAAC5tRUXpDqRcTvpvKF...(truncated unsigned transaction envelope)",
+    metadata: {
+      contractId: EXAMPLE_CONTRACT_ID,
+      networkPassphrase: "Test SDF Network ; September 2015",
+      sourceAccount: EXAMPLE_OWNER,
+      operation,
+    },
+  };
+}
+
 const ApiErrorSchema = registry.register(
   "ApiError",
-  z.object({
-    error: z.string().describe("Machine-readable error code"),
-    message: z.string().optional().describe("Human-readable error message"),
-    requestId: z.string().optional().describe("Request correlation ID"),
-    details: z.record(z.string(), z.unknown()).optional().describe("Additional error context"),
-  })
+  z
+    .object({
+      error: z.string().describe("Machine-readable error code"),
+      message: z.string().optional().describe("Human-readable error message"),
+      requestId: z.string().optional().describe("Request correlation ID"),
+      details: z.record(z.string(), z.unknown()).optional().describe("Additional error context"),
+    })
+    .openapi({
+      example: {
+        error: "VALIDATION_ERROR",
+        message: "collaborators basisPoints must sum to exactly 10000",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { path: ["collaborators"] },
+      },
+    })
 );
 
-function apiErrorResponse(description: string) {
+function apiErrorResponse(description: string, example?: Record<string, unknown>) {
   return {
     description,
     content: {
       "application/json": {
         schema: ApiErrorSchema,
+        ...(example ? { example } : {}),
       },
     },
   };
@@ -66,6 +116,7 @@ function apiErrorResponse(description: string) {
 
 function standardErrorResponses(options: {
   badRequest?: boolean;
+  badRequestExample?: Record<string, unknown>;
   unauthorized?: boolean;
   notFound?: boolean;
   conflict?: boolean;
@@ -74,9 +125,23 @@ function standardErrorResponses(options: {
   unavailable?: boolean;
 } = {}) {
   const responses: Record<number, ReturnType<typeof apiErrorResponse>> = {};
-  if (options.badRequest) responses[400] = apiErrorResponse("Validation error");
-  if (options.unauthorized) responses[401] = apiErrorResponse("Authentication required");
-  if (options.notFound) responses[404] = apiErrorResponse("Resource not found");
+  if (options.badRequest) {
+    responses[400] = apiErrorResponse("Validation error", options.badRequestExample);
+  }
+  if (options.unauthorized) {
+    responses[401] = apiErrorResponse("Authentication required", {
+      error: "UNAUTHORIZED",
+      message: "Missing or invalid bearer token / admin API key.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
+  if (options.notFound) {
+    responses[404] = apiErrorResponse("Resource not found", {
+      error: "NOT_FOUND",
+      message: `Project ${EXAMPLE_PROJECT_ID} does not exist.`,
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
   if (options.conflict) responses[409] = apiErrorResponse("Conflict with existing resource");
   if (options.serverError) responses[500] = apiErrorResponse("Internal server error");
   if (options.badGateway) responses[502] = apiErrorResponse("Upstream RPC or contract error");
@@ -155,27 +220,52 @@ registry.registerPath({
   method: "post",
   path: "/splits",
   summary: "Create a new split project",
-  description: "Builds an unsigned Soroban transaction XDR to create a new revenue-split project on-chain.",
+  description:
+    "Builds an unsigned Soroban transaction XDR to create a new revenue-split project on-chain. " +
+    "The caller must sign the returned XDR with the `owner` wallet and submit it themselves; " +
+    "this endpoint never holds a private key.",
   tags: ["Splits"],
   request: {
     body: {
       content: {
         "application/json": {
           schema: createSplitSchema,
+          example: {
+            owner: EXAMPLE_OWNER,
+            projectId: EXAMPLE_PROJECT_ID,
+            title: "Afrobeats Collective Vol. 1",
+            projectType: "music",
+            token: EXAMPLE_TOKEN,
+            collaborators: [
+              { address: EXAMPLE_COLLAB_A, alias: "Producer", basisPoints: 6000 },
+              { address: EXAMPLE_COLLAB_B, alias: "Vocalist", basisPoints: 4000 },
+            ],
+          },
         },
       },
     },
   },
   responses: {
     200: {
-      description: "Unsigned transaction XDR",
+      description: "Unsigned transaction XDR ready for the owner to sign and submit",
       content: {
         "application/json": {
           schema: XdrResponseSchema,
+          example: xdrExample("create_project"),
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({
+      badRequest: true,
+      badGateway: true,
+      serverError: true,
+      badRequestExample: {
+        error: "VALIDATION_ERROR",
+        message: "collaborators basisPoints must sum to exactly 10000",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { path: ["collaborators"] },
+      },
+    }),
   },
 });
 
@@ -237,11 +327,15 @@ registry.registerPath({
   description: "Builds an unsigned XDR to deposit tokens into a split project's escrow balance.",
   tags: ["Splits"],
   request: {
-    params: z.object({ projectId: projectIdParamSchema }),
+    params: z.object({ projectId: exampleProjectIdParam }),
     body: {
       content: {
         "application/json": {
           schema: depositSchema,
+          example: {
+            from: EXAMPLE_COLLAB_A,
+            amount: 50_000_000,
+          },
         },
       },
     },
@@ -252,10 +346,22 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: XdrResponseSchema,
+          example: xdrExample("deposit"),
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({
+      badRequest: true,
+      notFound: true,
+      badGateway: true,
+      serverError: true,
+      badRequestExample: {
+        error: "VALIDATION_ERROR",
+        message: "amount must be greater than 0",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { path: ["amount"] },
+      },
+    }),
   },
 });
 
@@ -292,14 +398,25 @@ registry.registerPath({
   method: "put",
   path: "/splits/{projectId}/collaborators",
   summary: "Update project collaborators",
-  description: "Builds an unsigned XDR to replace the collaborator list and revenue share allocations.",
+  description:
+    "Builds an unsigned XDR to replace the collaborator list and revenue share allocations. " +
+    "Fails validation if any address repeats or shares don't sum to 10,000 basis points; " +
+    "the frontend CreateSplitWizard performs the same duplicate/casing checks client-side, " +
+    "but this endpoint is the source of truth.",
   tags: ["Splits"],
   request: {
-    params: z.object({ projectId: projectIdParamSchema }),
+    params: z.object({ projectId: exampleProjectIdParam }),
     body: {
       content: {
         "application/json": {
           schema: updateCollaboratorsSchema,
+          example: {
+            owner: EXAMPLE_OWNER,
+            collaborators: [
+              { address: EXAMPLE_COLLAB_A, alias: "Producer", basisPoints: 5000 },
+              { address: EXAMPLE_COLLAB_B, alias: "Vocalist", basisPoints: 5000 },
+            ],
+          },
         },
       },
     },
@@ -310,10 +427,22 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: XdrResponseSchema,
+          example: xdrExample("update_collaborators"),
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({
+      badRequest: true,
+      notFound: true,
+      badGateway: true,
+      serverError: true,
+      badRequestExample: {
+        error: "VALIDATION_ERROR",
+        message: "duplicate collaborator address found",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { path: ["collaborators"] },
+      },
+    }),
   },
 });
 
@@ -324,11 +453,14 @@ registry.registerPath({
   description: "Builds an unsigned XDR to distribute accumulated project funds according to collaborator shares.",
   tags: ["Splits"],
   request: {
-    params: z.object({ projectId: projectIdParamSchema }),
+    params: z.object({ projectId: exampleProjectIdParam }),
     body: {
       content: {
         "application/json": {
           schema: distributeSchema,
+          example: {
+            sourceAddress: EXAMPLE_OWNER,
+          },
         },
       },
     },
@@ -339,10 +471,22 @@ registry.registerPath({
       content: {
         "application/json": {
           schema: XdrResponseSchema,
+          example: xdrExample("distribute"),
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({
+      badRequest: true,
+      notFound: true,
+      badGateway: true,
+      serverError: true,
+      badRequestExample: {
+        error: "VALIDATION_ERROR",
+        message: "Invalid projectId format.",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { path: ["projectId"] },
+      },
+    }),
   },
 });
 
@@ -415,10 +559,12 @@ registry.registerPath({
   method: "get",
   path: "/splits/{projectId}/history",
   summary: "Get project transaction history",
-  description: "Returns paginated on-chain distribution and payment events for a project.",
+  description:
+    "Returns paginated on-chain distribution (`round`) and payout (`payment`) events for a project, " +
+    "newest first. Pass the previous response's `nextCursor` back as the `cursor` query parameter to page forward.",
   tags: ["Splits"],
   request: {
-    params: z.object({ projectId: projectIdParamSchema }),
+    params: z.object({ projectId: exampleProjectIdParam }),
     query: historyQuerySchema,
   },
   responses: {
@@ -430,10 +576,137 @@ registry.registerPath({
             items: z.array(z.any()),
             nextCursor: z.string().nullable(),
           }),
+          example: {
+            items: [
+              {
+                type: "payment",
+                recipient: EXAMPLE_COLLAB_A,
+                amount: "3000000",
+                txHash: EXAMPLE_TX_HASH,
+                ledgerCloseTime: "1732012800",
+                id: "0000012345678901234-0000000001",
+              },
+              {
+                type: "round",
+                round: 3,
+                amount: "5000000",
+                txHash: EXAMPLE_TX_HASH,
+                ledgerCloseTime: "1732012700",
+                id: "0000012345678901233-0000000001",
+              },
+            ],
+            nextCursor: "0000012345678901233-0000000001",
+          },
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, notFound: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({
+      badRequest: true,
+      notFound: true,
+      badGateway: true,
+      serverError: true,
+      badRequestExample: {
+        error: "VALIDATION_ERROR",
+        message: "Invalid query parameters.",
+        requestId: EXAMPLE_REQUEST_ID,
+        details: { message: "Check cursor and limit parameters." },
+      },
+    }),
+  },
+});
+
+// ─── Events (Server-Sent Events) ───────────────────────────────────────────────
+//
+// Both endpoints hold the HTTP response open and stream `text/event-stream`
+// frames; OpenAPI 3.0 has no native way to type individual named SSE events,
+// so the shape of each event's `data:` payload is documented in the
+// description and mirrored from backend/src/__tests__/events.test.ts and
+// events-transactions-sse.test.ts.
+
+registry.registerPath({
+  method: "get",
+  path: "/events",
+  summary: "Observe transaction status updates for a submitted XDR (SSE)",
+  description:
+    "Opens a Server-Sent Events stream and emits a `transaction_update` event each time the " +
+    "backend observes an update for the given `txHash`. Limited to 5 concurrent subscribers " +
+    "per `txHash` (configurable via `SSE_MAX_LISTENERS_PER_TXHASH`); exceeding it returns 429.\n\n" +
+    "Example frame:\n" +
+    "```\n" +
+    "event: transaction_update\n" +
+    `data: {"txHash":"${EXAMPLE_TX_HASH}","status":"pending"}\n` +
+    "\n" +
+    "```",
+  tags: ["Events"],
+  request: {
+    query: z.object({
+      txHash: z.string().min(1).openapi({ example: EXAMPLE_TX_HASH }).describe("Transaction hash to observe"),
+    }),
+  },
+  responses: {
+    200: {
+      description: "text/event-stream of `transaction_update` frames (connection stays open)",
+      content: {
+        "text/event-stream": {
+          schema: z.string().openapi({
+            example: `event: transaction_update\ndata: {"txHash":"${EXAMPLE_TX_HASH}","status":"pending"}\n\n`,
+          }),
+        },
+      },
+    },
+    429: {
+      description: "Too many concurrent subscribers for this txHash",
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+          example: {
+            error: "too_many_event_listeners",
+            code: "RESOURCE_LIMIT_EXCEEDED",
+            message: "Too many event stream subscribers for this transaction.",
+            requestId: EXAMPLE_REQUEST_ID,
+            details: { txHash: EXAMPLE_TX_HASH, limit: 5 },
+          },
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true }),
+  },
+});
+
+registry.registerPath({
+  method: "get",
+  path: "/events/transactions/{txHash}",
+  summary: "Observe a single transaction until it's confirmed (SSE)",
+  description:
+    "Opens a Server-Sent Events stream and emits one `transaction:confirmed` event with the " +
+    "full transaction record once `EventListenerService` observes it on-chain. Sends a `: heartbeat` " +
+    "comment every 15s to keep intermediary proxies from closing the connection.\n\n" +
+    "Example frame:\n" +
+    "```\n" +
+    "event: transaction:confirmed\n" +
+    `data: {"txHash":"${EXAMPLE_TX_HASH}","roundId":"${EXAMPLE_PROJECT_ID}","recipient":"${EXAMPLE_COLLAB_A}","amount":"1000","token":"native","timestamp":1732012800,"status":"completed"}\n` +
+    "\n" +
+    "```",
+  tags: ["Events"],
+  request: {
+    params: z.object({
+      txHash: z.string().min(1).openapi({ example: EXAMPLE_TX_HASH }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "text/event-stream of a single `transaction:confirmed` frame (connection stays open until then)",
+      content: {
+        "text/event-stream": {
+          schema: z.string().openapi({
+            example:
+              `event: transaction:confirmed\ndata: {"txHash":"${EXAMPLE_TX_HASH}","roundId":"${EXAMPLE_PROJECT_ID}",` +
+              `"recipient":"${EXAMPLE_COLLAB_A}","amount":"1000","token":"native","timestamp":1732012800,"status":"completed"}\n\n`,
+          }),
+        },
+      },
+    },
+    ...standardErrorResponses({ badRequest: true }),
   },
 });
 
@@ -453,6 +726,7 @@ registry.registerPath({
   summary: "List allowed payment tokens",
   description: "Returns the contract admin address, total allowed token count, and a paginated token allowlist.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: { query: allowlistQuerySchema },
   responses: {
     200: {
@@ -477,6 +751,7 @@ registry.registerPath({
   summary: "Allow a payment token",
   description: "Builds an unsigned XDR to add a token to the contract allowlist. Requires admin API key.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: {
     body: { content: { "application/json": { schema: adminTokenSchema } } },
   },
@@ -492,6 +767,7 @@ registry.registerPath({
   summary: "Disallow a payment token",
   description: "Builds an unsigned XDR to remove a token from the contract allowlist. Requires admin API key.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: {
     body: { content: { "application/json": { schema: adminTokenSchema } } },
   },
@@ -507,6 +783,7 @@ registry.registerPath({
   summary: "Pause all distributions",
   description: "Builds an unsigned XDR to pause contract-wide fund distributions. Requires admin API key.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: {
     body: { content: { "application/json": { schema: pauseDistributionsSchema } } },
   },
@@ -522,6 +799,7 @@ registry.registerPath({
   summary: "Unpause distributions",
   description: "Builds an unsigned XDR to resume contract-wide fund distributions. Requires admin API key.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: {
     body: { content: { "application/json": { schema: pauseDistributionsSchema } } },
   },
@@ -537,6 +815,7 @@ registry.registerPath({
   summary: "Get admin contract status",
   description: "Returns the current contract admin address and whether distributions are paused.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   responses: {
     200: {
       description: "Admin status",
@@ -552,6 +831,7 @@ registry.registerPath({
   summary: "Check if a token is allowed",
   description: "Returns whether a specific token contract address is on the allowlist.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: { query: isTokenAllowedQuerySchema },
   responses: {
     200: {
@@ -572,6 +852,7 @@ registry.registerPath({
   summary: "Get allowed token count",
   description: "Returns the total number of tokens on the contract allowlist.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   responses: {
     200: {
       description: "Allowed token count",
@@ -591,6 +872,7 @@ registry.registerPath({
   summary: "Get unallocated token balance",
   description: "Returns the unallocated balance held by the contract for a given token.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: { query: unallocatedQuerySchema },
   responses: {
     200: {
@@ -611,6 +893,7 @@ registry.registerPath({
   summary: "Withdraw unallocated tokens",
   description: "Builds an unsigned XDR to recover unallocated token balance from the contract. Requires admin API key.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   request: {
     body: { content: { "application/json": { schema: withdrawUnallocatedSchema } } },
   },
@@ -626,6 +909,7 @@ registry.registerPath({
   summary: "Get read cache statistics",
   description: "Returns internal read-cache hit/miss statistics for diagnostics.",
   tags: ["Admin"],
+  security: [{ adminApiKey: [] }],
   responses: {
     200: {
       description: "Cache statistics",
@@ -1039,7 +1323,7 @@ const isDirectRun = process.argv[1] && (
 
 if (isDirectRun) {
   const spec = generateOpenApi();
-  const docsDir = path.join(process.cwd(), "openapi");
+  const docsDir = path.join(path.dirname(__filename), "..", "..", "docs");
   if (!fs.existsSync(docsDir)) {
     fs.mkdirSync(docsDir, { recursive: true });
   }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,2625 @@
+openapi: 3.0.0
+info:
+  version: 0.1.0
+  title: SplitNaira API
+  description: Premium royalty management API on Stellar network.
+servers:
+  - url: http://localhost:3001
+components:
+  schemas:
+    ApiError:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+        requestId:
+          type: string
+          description: Request correlation ID
+        details:
+          type: object
+          additionalProperties:
+            nullable: true
+          description: Additional error context
+      required:
+        - error
+      example:
+        error: VALIDATION_ERROR
+        message: collaborators basisPoints must sum to exactly 10000
+        requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        details:
+          path:
+            - collaborators
+    Project:
+      type: object
+      properties:
+        projectId:
+          type: string
+        title:
+          type: string
+        projectType:
+          type: string
+        owner:
+          type: string
+        token:
+          type: string
+        balance:
+          type: string
+        totalDistributed:
+          type: string
+        locked:
+          type: boolean
+        collaborators:
+          type: array
+          items:
+            type: object
+            properties:
+              address:
+                type: string
+              alias:
+                type: string
+              basisPoints:
+                type: number
+            required:
+              - address
+              - alias
+              - basisPoints
+      required:
+        - projectId
+        - title
+        - projectType
+        - owner
+        - token
+        - balance
+        - totalDistributed
+        - locked
+        - collaborators
+    XdrResponse:
+      type: object
+      properties:
+        xdr:
+          type: string
+        metadata:
+          type: object
+          properties:
+            contractId:
+              type: string
+            networkPassphrase:
+              type: string
+            sourceAccount:
+              type: string
+            operation:
+              type: string
+          required:
+            - contractId
+            - networkPassphrase
+            - sourceAccount
+            - operation
+      required:
+        - xdr
+        - metadata
+    ClaimableResponse:
+      type: object
+      properties:
+        projectId:
+          type: string
+          description: The project ID
+        collaborator:
+          type: string
+          description: Stellar address of the collaborator
+        claimable:
+          type: string
+          description: Amount available to claim, in stroops
+        claimed:
+          type: string
+          description: Amount already claimed, in stroops
+        total:
+          type: string
+          description: Total allocated (claimed + claimable), in stroops
+      required:
+        - projectId
+        - collaborator
+        - claimable
+        - claimed
+        - total
+    AdminStatus:
+      type: object
+      properties:
+        admin:
+          type: string
+          nullable: true
+        isPaused:
+          type: boolean
+      required:
+        - admin
+        - isPaused
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+            - not_ready
+        uptime:
+          type: number
+          description: Server uptime in seconds
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp
+      required:
+        - status
+    ReadinessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - ready
+            - not_ready
+        error:
+          type: string
+          description: Error code if not ready
+        message:
+          type: string
+          description: Error message if not ready
+        issues:
+          type: array
+          items:
+            type: string
+          description: List of configuration issues
+        requestId:
+          type: string
+          description: Request ID for tracing
+      required:
+        - status
+    MainnetReadinessResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - ready
+            - not_ready
+        requestId:
+          type: string
+        error:
+          type: string
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: {}
+        components:
+          type: object
+          properties:
+            env:
+              type: object
+              properties:
+                ok:
+                  type: boolean
+                message:
+                  type: string
+                details:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - ok
+            db:
+              type: object
+              properties:
+                ok:
+                  type: boolean
+                message:
+                  type: string
+                details:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - ok
+            cache:
+              type: object
+              properties:
+                ok:
+                  type: boolean
+                message:
+                  type: string
+                details:
+                  type: object
+                  additionalProperties: {}
+              required:
+                - ok
+            deploy:
+              type: object
+              properties:
+                ok:
+                  type: boolean
+                message:
+                  type: string
+                productionSecrets:
+                  type: object
+                  properties:
+                    mainnetContractId:
+                      type: boolean
+                    renderBackendDeployHookUrl:
+                      type: boolean
+                  required:
+                    - mainnetContractId
+                    - renderBackendDeployHookUrl
+                contractIdMatch:
+                  type: boolean
+                databasePoolMax:
+                  type: number
+                readCacheTtlMs:
+                  type: number
+                readCacheMaxEntries:
+                  type: number
+              required:
+                - ok
+          required:
+            - env
+            - db
+            - cache
+            - deploy
+      required:
+        - status
+        - components
+  parameters: {}
+paths:
+  /splits:
+    get:
+      summary: List all split projects
+      description: Returns a paginated list of on-chain split projects with optional
+        search and type filters.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: integer
+            nullable: true
+            minimum: 0
+            default: 0
+          required: false
+          name: start
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 10
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: search
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: type
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: cursor
+          in: query
+      responses:
+        "200":
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Project"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    post:
+      summary: Create a new split project
+      description: Builds an unsigned Soroban transaction XDR to create a new
+        revenue-split project on-chain. The caller must sign the returned XDR
+        with the `owner` wallet and submit it themselves; this endpoint never
+        holds a private key.
+      tags:
+        - Splits
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                owner:
+                  type: string
+                  minLength: 1
+                  description: owner
+                projectId:
+                  type: string
+                  minLength: 1
+                  maxLength: 32
+                  pattern: ^[a-zA-Z0-9_]+$
+                title:
+                  type: string
+                projectType:
+                  type: string
+                token:
+                  type: string
+                  minLength: 1
+                  description: token
+                collaborators:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      address:
+                        type: string
+                        minLength: 1
+                      alias:
+                        type: string
+                        minLength: 1
+                        maxLength: 100
+                      basisPoints:
+                        type: integer
+                        minimum: 0
+                        exclusiveMinimum: true
+                        maximum: 10000
+                    required:
+                      - address
+                      - alias
+                      - basisPoints
+                  minItems: 2
+              required:
+                - owner
+                - projectId
+                - title
+                - projectType
+                - token
+                - collaborators
+            example:
+              owner: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+              projectId: afrobeats_001
+              title: Afrobeats Collective Vol. 1
+              projectType: music
+              token: CDOVDY3MZDG7PHCGVP7EP2EKQ2ENV26DZW6FKLBRN42LOGIZGXZV3WX5
+              collaborators:
+                - address: GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV
+                  alias: Producer
+                  basisPoints: 6000
+                - address: GBG234UA6RBPDD5K6FHMQXHUXB5ALOENQGH24Y3W4ERX2YJNQ4MK4V25
+                  alias: Vocalist
+                  basisPoints: 4000
+      responses:
+        "200":
+          description: Unsigned transaction XDR ready for the owner to sign and submit
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+              example:
+                xdr: AAAAAgAAAAC5tRUXpDqRcTvpvKF...(truncated unsigned transaction envelope)
+                metadata:
+                  contractId: CAGR5U5IBEPFVJDZPZUXXNCPXAHNZ6TWVIUTI5RLRH3SZSU4O2VXDOPF
+                  networkPassphrase: Test SDF Network ; September 2015
+                  sourceAccount: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+                  operation: create_project
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: VALIDATION_ERROR
+                message: collaborators basisPoints must sum to exactly 10000
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  path:
+                    - collaborators
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}:
+    get:
+      summary: Get project details by ID
+      description: Fetches the current on-chain state for a single split project
+        including collaborators and balances.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+          required: true
+          name: projectId
+          in: path
+      responses:
+        "200":
+          description: Project details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/lock:
+    post:
+      summary: Lock a project permanently
+      description: Builds an unsigned XDR to permanently lock a project, preventing
+        further metadata or collaborator changes.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+          required: true
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                owner:
+                  type: string
+                  minLength: 1
+                  description: owner
+              required:
+                - owner
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/deposit:
+    post:
+      summary: Deposit funds into a project
+      description: Builds an unsigned XDR to deposit tokens into a split project's
+        escrow balance.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+            example: afrobeats_001
+            description: Project ID
+          required: true
+          description: Project ID
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                from:
+                  type: string
+                  minLength: 1
+                  description: from
+                amount:
+                  type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: deposit amount in stroops
+              required:
+                - from
+                - amount
+            example:
+              from: GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV
+              amount: 50000000
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+              example:
+                xdr: AAAAAgAAAAC5tRUXpDqRcTvpvKF...(truncated unsigned transaction envelope)
+                metadata:
+                  contractId: CAGR5U5IBEPFVJDZPZUXXNCPXAHNZ6TWVIUTI5RLRH3SZSU4O2VXDOPF
+                  networkPassphrase: Test SDF Network ; September 2015
+                  sourceAccount: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+                  operation: deposit
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: VALIDATION_ERROR
+                message: amount must be greater than 0
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  path:
+                    - amount
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/metadata:
+    patch:
+      summary: Update project metadata (title/category)
+      description: Builds an unsigned XDR to update a project's title and project
+        type. Text fields are server-side sanitized.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+          required: true
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                owner:
+                  type: string
+                  minLength: 1
+                  description: owner
+                title:
+                  type: string
+                projectType:
+                  type: string
+              required:
+                - owner
+                - title
+                - projectType
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/collaborators:
+    put:
+      summary: Update project collaborators
+      description: Builds an unsigned XDR to replace the collaborator list and revenue
+        share allocations. Fails validation if any address repeats or shares
+        don't sum to 10,000 basis points; the frontend CreateSplitWizard
+        performs the same duplicate/casing checks client-side, but this endpoint
+        is the source of truth.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+            example: afrobeats_001
+            description: Project ID
+          required: true
+          description: Project ID
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                owner:
+                  type: string
+                  minLength: 1
+                  description: owner
+                collaborators:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      address:
+                        type: string
+                        minLength: 1
+                      alias:
+                        type: string
+                        minLength: 1
+                        maxLength: 100
+                      basisPoints:
+                        type: integer
+                        minimum: 0
+                        exclusiveMinimum: true
+                        maximum: 10000
+                    required:
+                      - address
+                      - alias
+                      - basisPoints
+                  minItems: 2
+              required:
+                - owner
+                - collaborators
+            example:
+              owner: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+              collaborators:
+                - address: GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV
+                  alias: Producer
+                  basisPoints: 5000
+                - address: GBG234UA6RBPDD5K6FHMQXHUXB5ALOENQGH24Y3W4ERX2YJNQ4MK4V25
+                  alias: Vocalist
+                  basisPoints: 5000
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+              example:
+                xdr: AAAAAgAAAAC5tRUXpDqRcTvpvKF...(truncated unsigned transaction envelope)
+                metadata:
+                  contractId: CAGR5U5IBEPFVJDZPZUXXNCPXAHNZ6TWVIUTI5RLRH3SZSU4O2VXDOPF
+                  networkPassphrase: Test SDF Network ; September 2015
+                  sourceAccount: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+                  operation: update_collaborators
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: VALIDATION_ERROR
+                message: duplicate collaborator address found
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  path:
+                    - collaborators
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/distribute:
+    post:
+      summary: Distribute project funds to collaborators
+      description: Builds an unsigned XDR to distribute accumulated project funds
+        according to collaborator shares.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+            example: afrobeats_001
+            description: Project ID
+          required: true
+          description: Project ID
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                sourceAddress:
+                  type: string
+                  minLength: 1
+            example:
+              sourceAddress: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+              example:
+                xdr: AAAAAgAAAAC5tRUXpDqRcTvpvKF...(truncated unsigned transaction envelope)
+                metadata:
+                  contractId: CAGR5U5IBEPFVJDZPZUXXNCPXAHNZ6TWVIUTI5RLRH3SZSU4O2VXDOPF
+                  networkPassphrase: Test SDF Network ; September 2015
+                  sourceAccount: GBJRKIYXAAFD3NZCWJXGUTNKYUQFZC2ANS6LRMBPJCE4IZSMJJMZPQBT
+                  operation: distribute
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: VALIDATION_ERROR
+                message: Invalid projectId format.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  path:
+                    - projectId
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/claimable/{collaborator}:
+    get:
+      summary: Get claimable payout information for a collaborator
+      description: Returns the claimable, claimed, and total allocated amounts for a
+        collaborator on a project.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+          required: true
+          name: projectId
+          in: path
+        - schema:
+            type: string
+            minLength: 1
+            description: Stellar address of the collaborator
+          required: true
+          description: Stellar address of the collaborator
+          name: collaborator
+          in: path
+      responses:
+        "200":
+          description: Claimable payout information
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimableResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/claim:
+    post:
+      summary: Claim collaborator payout
+      description: Builds an unsigned XDR allowing a collaborator to claim their
+        allocated share from a project.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+          required: true
+          name: projectId
+          in: path
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                claimer:
+                  type: string
+                  minLength: 1
+                  description: collaborator address performing the claim
+              required:
+                - claimer
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/{projectId}/history:
+    get:
+      summary: Get project transaction history
+      description: Returns paginated on-chain distribution (`round`) and payout
+        (`payment`) events for a project, newest first. Pass the previous
+        response's `nextCursor` back as the `cursor` query parameter to page
+        forward.
+      tags:
+        - Splits
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 32
+            pattern: ^[a-zA-Z0-9_]+$
+            example: afrobeats_001
+            description: Project ID
+          required: true
+          description: Project ID
+          name: projectId
+          in: path
+        - schema:
+            type: string
+            default: ""
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 100
+          required: false
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: History items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      nullable: true
+                  nextCursor:
+                    type: string
+                    nullable: true
+                required:
+                  - items
+                  - nextCursor
+              example:
+                items:
+                  - type: payment
+                    recipient: GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV
+                    amount: "3000000"
+                    txHash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc
+                    ledgerCloseTime: "1732012800"
+                    id: 0000012345678901234-0000000001
+                  - type: round
+                    round: 3
+                    amount: "5000000"
+                    txHash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc
+                    ledgerCloseTime: "1732012700"
+                    id: 0000012345678901233-0000000001
+                nextCursor: 0000012345678901233-0000000001
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: VALIDATION_ERROR
+                message: Invalid query parameters.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  message: Check cursor and limit parameters.
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /events:
+    get:
+      summary: Observe transaction status updates for a submitted XDR (SSE)
+      description: |-
+        Opens a Server-Sent Events stream and emits a `transaction_update` event each time the backend observes an update for the given `txHash`. Limited to 5 concurrent subscribers per `txHash` (configurable via `SSE_MAX_LISTENERS_PER_TXHASH`); exceeding it returns 429.
+
+        Example frame:
+        ```
+        event: transaction_update
+        data: {"txHash":"3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc","status":"pending"}
+
+        ```
+      tags:
+        - Events
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            example: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc
+            description: Transaction hash to observe
+          required: true
+          description: Transaction hash to observe
+          name: txHash
+          in: query
+      responses:
+        "200":
+          description: text/event-stream of `transaction_update` frames (connection stays
+            open)
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                example: |+
+                  event: transaction_update
+                  data: {"txHash":"3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc","status":"pending"}
+
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many concurrent subscribers for this txHash
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: too_many_event_listeners
+                code: RESOURCE_LIMIT_EXCEEDED
+                message: Too many event stream subscribers for this transaction.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+                details:
+                  txHash: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc
+                  limit: 5
+  /events/transactions/{txHash}:
+    get:
+      summary: Observe a single transaction until it's confirmed (SSE)
+      description: |-
+        Opens a Server-Sent Events stream and emits one `transaction:confirmed` event with the full transaction record once `EventListenerService` observes it on-chain. Sends a `: heartbeat` comment every 15s to keep intermediary proxies from closing the connection.
+
+        Example frame:
+        ```
+        event: transaction:confirmed
+        data: {"txHash":"3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc","roundId":"afrobeats_001","recipient":"GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV","amount":"1000","token":"native","timestamp":1732012800,"status":"completed"}
+
+        ```
+      tags:
+        - Events
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            example: 3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc
+          required: true
+          name: txHash
+          in: path
+      responses:
+        "200":
+          description: text/event-stream of a single `transaction:confirmed` frame
+            (connection stays open until then)
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                example: |+
+                  event: transaction:confirmed
+                  data: {"txHash":"3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8fc","roundId":"afrobeats_001","recipient":"GCZTK3PNYXCVF7Z3ELVELEJZ7BVGPGPVJ3NVZNI7O6DVCHPA4JU6LXRV","amount":"1000","token":"native","timestamp":1732012800,"status":"completed"}
+
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/allowlist:
+    get:
+      summary: List allowed payment tokens
+      description: Returns the contract admin address, total allowed token count, and
+        a paginated token allowlist.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      parameters:
+        - schema:
+            type: integer
+            nullable: true
+            minimum: 0
+            default: 0
+          required: false
+          name: start
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 100
+          required: false
+          name: limit
+          in: query
+      responses:
+        "200":
+          description: Token allowlist page
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  admin:
+                    type: string
+                    nullable: true
+                  count:
+                    type: integer
+                  tokens:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - admin
+                  - count
+                  - tokens
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/allow-token:
+    post:
+      summary: Allow a payment token
+      description: Builds an unsigned XDR to add a token to the contract allowlist.
+        Requires admin API key.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin:
+                  type: string
+                  minLength: 1
+                  description: admin
+                token:
+                  type: string
+                  minLength: 1
+                  description: token
+              required:
+                - admin
+                - token
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "503":
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/disallow-token:
+    post:
+      summary: Disallow a payment token
+      description: Builds an unsigned XDR to remove a token from the contract
+        allowlist. Requires admin API key.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin:
+                  type: string
+                  minLength: 1
+                  description: admin
+                token:
+                  type: string
+                  minLength: 1
+                  description: token
+              required:
+                - admin
+                - token
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "503":
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/pause-distributions:
+    post:
+      summary: Pause all distributions
+      description: Builds an unsigned XDR to pause contract-wide fund distributions.
+        Requires admin API key.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin:
+                  type: string
+                  minLength: 1
+                  description: admin
+              required:
+                - admin
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "503":
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/unpause-distributions:
+    post:
+      summary: Unpause distributions
+      description: Builds an unsigned XDR to resume contract-wide fund distributions.
+        Requires admin API key.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin:
+                  type: string
+                  minLength: 1
+                  description: admin
+              required:
+                - admin
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "503":
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/status:
+    get:
+      summary: Get admin contract status
+      description: Returns the current contract admin address and whether
+        distributions are paused.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Admin status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminStatus"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/is-token-allowed:
+    get:
+      summary: Check if a token is allowed
+      description: Returns whether a specific token contract address is on the allowlist.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            description: token contract address to check
+          required: true
+          description: token contract address to check
+          name: token
+          in: query
+      responses:
+        "200":
+          description: Token allowlist check result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  isAllowed:
+                    type: boolean
+                required:
+                  - token
+                  - isAllowed
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/token-count:
+    get:
+      summary: Get allowed token count
+      description: Returns the total number of tokens on the contract allowlist.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Allowed token count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                required:
+                  - count
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/unallocated:
+    get:
+      summary: Get unallocated token balance
+      description: Returns the unallocated balance held by the contract for a given token.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+            description: token contract address
+          required: true
+          description: token contract address
+          name: token
+          in: query
+      responses:
+        "200":
+          description: Unallocated balance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                  unallocated:
+                    type: string
+                required:
+                  - token
+                  - unallocated
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/withdraw-unallocated:
+    post:
+      summary: Withdraw unallocated tokens
+      description: Builds an unsigned XDR to recover unallocated token balance from
+        the contract. Requires admin API key.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                admin:
+                  type: string
+                  minLength: 1
+                  description: admin
+                token:
+                  type: string
+                  minLength: 1
+                  description: token contract address
+                to:
+                  type: string
+                  minLength: 1
+                  description: destination address
+                amount:
+                  type: number
+                  minimum: 0
+                  exclusiveMinimum: true
+                  description: amount in stroops to recover
+              required:
+                - admin
+                - token
+                - to
+                - amount
+      responses:
+        "200":
+          description: Unsigned transaction XDR
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/XdrResponse"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Upstream RPC or contract error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "503":
+          description: Service temporarily unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /splits/admin/cache-stats:
+    get:
+      summary: Get read cache statistics
+      description: Returns internal read-cache hit/miss statistics for diagnostics.
+      tags:
+        - Admin
+      security:
+        - adminApiKey: []
+      responses:
+        "200":
+          description: Cache statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hits:
+                    type: integer
+                  misses:
+                    type: integer
+                  evictions:
+                    type: integer
+                  ttlMs:
+                    type: integer
+                required:
+                  - hits
+                  - misses
+                  - evictions
+                  - ttlMs
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /users/register:
+    post:
+      summary: Register a new user
+      description: Creates a user profile linked to a Stellar wallet address.
+      tags:
+        - Users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                walletAddress:
+                  type: string
+                  minLength: 1
+                email:
+                  type: string
+                  format: email
+                alias:
+                  type: string
+                  minLength: 1
+                  maxLength: 64
+              required:
+                - walletAddress
+      responses:
+        "201":
+          description: Registered user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  walletAddress:
+                    type: string
+                  email:
+                    type: string
+                  alias:
+                    type: string
+                  role:
+                    type: string
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - id
+                  - walletAddress
+                  - role
+                  - isActive
+                  - createdAt
+                  - updatedAt
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: Conflict with existing resource
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /users/login:
+    post:
+      summary: Log in by wallet address
+      description: Authenticates a registered user and returns a JWT bearer token.
+      tags:
+        - Users
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                walletAddress:
+                  type: string
+                  minLength: 1
+              required:
+                - walletAddress
+      responses:
+        "200":
+          description: Authenticated user with JWT
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  walletAddress:
+                    type: string
+                  email:
+                    type: string
+                  alias:
+                    type: string
+                  role:
+                    type: string
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                  token:
+                    type: string
+                required:
+                  - id
+                  - walletAddress
+                  - role
+                  - isActive
+                  - createdAt
+                  - updatedAt
+                  - token
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /users/me:
+    get:
+      summary: Get authenticated user profile
+      description: Returns the profile of the user identified by the JWT bearer token.
+      tags:
+        - Users
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Authenticated user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  walletAddress:
+                    type: string
+                  email:
+                    type: string
+                  alias:
+                    type: string
+                  role:
+                    type: string
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - id
+                  - walletAddress
+                  - role
+                  - isActive
+                  - createdAt
+                  - updatedAt
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    patch:
+      summary: Update authenticated user profile
+      description: Updates email or alias for the authenticated user.
+      tags:
+        - Users
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                alias:
+                  type: string
+                  minLength: 1
+                  maxLength: 64
+      responses:
+        "200":
+          description: Updated user profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  walletAddress:
+                    type: string
+                  email:
+                    type: string
+                  alias:
+                    type: string
+                  role:
+                    type: string
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - id
+                  - walletAddress
+                  - role
+                  - isActive
+                  - createdAt
+                  - updatedAt
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: UNAUTHORIZED
+                message: Missing or invalid bearer token / admin API key.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /users/{walletAddress}:
+    get:
+      summary: Get user by wallet address
+      description: Looks up a public user profile by Stellar wallet address.
+      tags:
+        - Users
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: walletAddress
+          in: path
+      responses:
+        "200":
+          description: User profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  walletAddress:
+                    type: string
+                  email:
+                    type: string
+                  alias:
+                    type: string
+                  role:
+                    type: string
+                  isActive:
+                    type: boolean
+                  createdAt:
+                    type: string
+                  updatedAt:
+                    type: string
+                required:
+                  - id
+                  - walletAddress
+                  - role
+                  - isActive
+                  - createdAt
+                  - updatedAt
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /transactions/history:
+    get:
+      summary: Query payout transaction history
+      description: Returns paginated payout records with optional wallet, date, and
+        status filters.
+      tags:
+        - Transactions
+      parameters:
+        - schema:
+            type: string
+            pattern: ^G[A-Z2-7]{55}$
+          required: false
+          name: walletAddress
+          in: query
+        - schema:
+            type: integer
+            minimum: 0
+            exclusiveMinimum: true
+          required: false
+          name: startDate
+          in: query
+        - schema:
+            type: integer
+            minimum: 0
+            exclusiveMinimum: true
+          required: false
+          name: endDate
+          in: query
+        - schema:
+            type: string
+            enum:
+              - pending
+              - completed
+              - failed
+          required: false
+          name: status
+          in: query
+        - schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: integer
+            nullable: true
+            minimum: 0
+            default: 0
+          required: false
+          name: offset
+          in: query
+      responses:
+        "200":
+          description: Paginated transaction history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        roundId:
+                          type: string
+                        recipient:
+                          type: string
+                        amount:
+                          type: string
+                        token:
+                          type: string
+                        timestamp:
+                          type: integer
+                        txHash:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - pending
+                            - completed
+                            - failed
+                      required:
+                        - id
+                        - roundId
+                        - recipient
+                        - amount
+                        - token
+                        - timestamp
+                        - txHash
+                        - status
+                  total:
+                    type: integer
+                    minimum: 0
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
+                required:
+                  - transactions
+                  - total
+                  - limit
+                  - offset
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /transactions/{txHash}:
+    get:
+      summary: Get transaction by hash
+      description: Returns a single payout record matching the Stellar transaction hash.
+      tags:
+        - Transactions
+      parameters:
+        - schema:
+            type: string
+            minLength: 1
+          required: true
+          name: txHash
+          in: path
+      responses:
+        "200":
+          description: Transaction record
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  roundId:
+                    type: string
+                  recipient:
+                    type: string
+                  amount:
+                    type: string
+                  token:
+                    type: string
+                  timestamp:
+                    type: integer
+                  txHash:
+                    type: string
+                  status:
+                    type: string
+                    enum:
+                      - pending
+                      - completed
+                      - failed
+                required:
+                  - id
+                  - roundId
+                  - recipient
+                  - amount
+                  - token
+                  - timestamp
+                  - txHash
+                  - status
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "404":
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: NOT_FOUND
+                message: Project afrobeats_001 does not exist.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /transactions/recipient/{walletAddress}:
+    get:
+      summary: List transactions for a recipient
+      description: Returns all payout records sent to the given Stellar wallet address.
+      tags:
+        - Transactions
+      parameters:
+        - schema:
+            type: string
+            pattern: ^G[A-Z2-7]{55}$
+          required: true
+          name: walletAddress
+          in: path
+      responses:
+        "200":
+          description: Recipient transaction list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        roundId:
+                          type: string
+                        recipient:
+                          type: string
+                        amount:
+                          type: string
+                        token:
+                          type: string
+                        timestamp:
+                          type: integer
+                        txHash:
+                          type: string
+                        status:
+                          type: string
+                          enum:
+                            - pending
+                            - completed
+                            - failed
+                      required:
+                        - id
+                        - roundId
+                        - recipient
+                        - amount
+                        - token
+                        - timestamp
+                        - txHash
+                        - status
+                  total:
+                    type: integer
+                  walletAddress:
+                    type: string
+                required:
+                  - transactions
+                  - total
+                  - walletAddress
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /health:
+    get:
+      summary: Get readiness status (alias for /health/ready)
+      tags:
+        - Health
+      responses:
+        "200":
+          description: Server is ready to accept traffic
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+        "503":
+          description: Server is not ready
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+  /health/live:
+    get:
+      summary: Liveness check (Kubernetes compatible)
+      tags:
+        - Health
+      responses:
+        "200":
+          description: Server is alive
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ok
+                required:
+                  - status
+  /health/ready:
+    get:
+      summary: Readiness check (Kubernetes compatible)
+      tags:
+        - Health
+      responses:
+        "200":
+          description: Server is ready to accept traffic
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - ready
+                required:
+                  - status
+        "503":
+          description: Server is not ready (missing configuration)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
+  /ops/mainnet-readiness:
+    get:
+      summary: Mainnet readiness validation for deployment and ops workflows
+      tags:
+        - Operations
+      responses:
+        "200":
+          description: Mainnet readiness validation passed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MainnetReadinessResponse"
+        "503":
+          description: Mainnet readiness validation failed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MainnetReadinessResponse"
+  /:
+    get:
+      summary: Get API information
+      tags:
+        - System
+      responses:
+        "200":
+          description: API metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                  version:
+                    type: string
+                required:
+                  - name
+                  - status
+                  - version

--- a/docs/runbooks/cicd-security.md
+++ b/docs/runbooks/cicd-security.md
@@ -2,6 +2,49 @@
 
 Operational guidance for supply-chain alerts, leaked secrets, and pipeline incidents.
 
+## Workflow Permissions Audit
+
+Every workflow declares a read-only `permissions: contents: read` default at the
+top level. Any elevated scope is granted on the specific job that needs it, not
+the whole workflow, so a compromised or buggy step in an unrelated job can't
+inherit write access it doesn't need.
+
+| Workflow | Default | Job-level exception | Why |
+|----------|---------|----------------------|-----|
+| `ci.yml` | `contents: read` | none | Build/test/lint only |
+| `codeql-analysis.yml` | `contents: read`, `security-events: write` | none (single job) | `analyze` job must upload SARIF results |
+| `dependency-audit.yml` | `contents: read` | none | `npm audit` only |
+| `frontend-ci.yml` | `contents: read` | none | Build/test/lint only |
+| `frontend-quality.yml` | `contents: read` | none | Build/test/lint only |
+| `user-onboarding-ci.yml` | `contents: read` | none | Build/test/lint only |
+| `testnet-integration.yml` | `contents: read` | none | Read-only API checks against live testnet |
+| `smoke-testnet.yml` | `contents: read` | none | Read-only contract call against live testnet |
+| `backend-deploy.yml` | `contents: read` | none | Deploys via Render webhook (`curl`); no repo writes |
+| `mainnet-deploy.yml` | `contents: read` | none | Deploys via Render webhook (`curl`); no repo writes |
+| `contract-testnet-deploy.yml` | `contents: read` | `deploy-testnet`: `contents: write` | Commits the redeployed contract id back to the repo |
+| `release.yml` | `contents: read` | `create-release`: `contents: write` | `ncipollo/release-action` publishes a draft GitHub Release |
+
+### Periodic audit checklist
+
+Run this whenever a workflow is added or its jobs/steps change, and at least
+quarterly:
+
+- [ ] Every workflow file has a top-level `permissions:` block (no file relies
+      on the repository/org default token permissions).
+- [ ] The top-level default is `contents: read` unless the workflow has no
+      job that touches repo contents or the GitHub API at all.
+- [ ] Any scope beyond `contents: read` (`contents: write`, `security-events:
+      write`, `id-token: write`, `pull-requests: write`, etc.) is declared on
+      the specific job that needs it, not the workflow default, unless the
+      workflow has exactly one job.
+- [ ] Each such exception is documented (table above + inline comment in the
+      workflow) with the reason it's required.
+- [ ] Deploy and release workflows use a GitHub `environment` (`staging`,
+      `production`, `testnet`) so elevated permissions and secrets are gated
+      by environment protection rules, not just the workflow trigger.
+- [ ] No workflow echoes secrets to logs or passes them to untrusted third-party
+      actions.
+
 ## Pipeline Overview
 
 | Workflow | Purpose | Security gate |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,6 +8,7 @@ Next.js app scaffold for the SplitNaira web experience.
 - `npm run build`
 - `npm run start`
 - `npm run test`
+- `npm run check:i18n` - fails if any locale's message keys don't match `en.json`
 
 ## Notes
 - Dependencies are pinned to exact versions in `package.json` and `package-lock.json`.
@@ -16,6 +17,17 @@ Next.js app scaffold for the SplitNaira web experience.
 - Configure `NEXT_PUBLIC_*` variables in `.env.local` based on `.env.example`.
 - i18n is powered by `next-intl`; locale-prefixed routes are enabled (e.g. `/en`, `/fr`).
 - To add another language, update `src/i18n/routing.ts` and add a matching `messages/<locale>.json`.
+
+### Adding a translation key
+1. Add the key to `messages/en.json` (the base locale) wherever it belongs in the nested structure.
+2. Add the same key, translated, to every other locale file (currently `messages/fr.json`).
+3. Run `npm run check:i18n` — it fails on any key that's missing from, or extra in, a non-base locale
+   relative to `en.json`. CI runs this on every PR (`ci.yml`, `frontend-ci.yml`, `frontend-quality.yml`).
+4. If a key is intentionally locale-specific (rare), add it to `messages/i18n-ignore.json` under
+   `ignoreMissingKeys.<locale>` or `ignoreExtraKeys.<locale>` instead of leaving locales out of sync:
+   ```json
+   { "ignoreMissingKeys": { "fr": ["SplitApp.experimentalFeature"] } }
+   ```
 
 ## Structure
 - `src/app` - App Router pages and layout

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --max-warnings=0",
-    "test": "vitest run"
+    "test": "vitest run",
+    "check:i18n": "node scripts/check-i18n-keys.mjs"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.2.0",

--- a/frontend/scripts/check-i18n-keys.mjs
+++ b/frontend/scripts/check-i18n-keys.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Issue #872: fails CI when a locale's message keys drift from the base
+// locale (en) — missing keys silently fall back to raw keys at runtime,
+// extra keys are usually leftover cruft from a removed feature.
+//
+// Usage: node scripts/check-i18n-keys.mjs
+// To intentionally allow a locale to differ from `en` for a specific key,
+// add it to messages/i18n-ignore.json (see that file's shape below).
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MESSAGES_DIR = path.join(__dirname, "..", "messages");
+const IGNORE_FILE = path.join(MESSAGES_DIR, "i18n-ignore.json");
+
+// Keep in sync with frontend/src/i18n/routing.ts `defaultLocale`.
+const BASE_LOCALE = "en";
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function flattenKeys(obj, prefix = "") {
+  const keys = [];
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      keys.push(...flattenKeys(value, path));
+    } else {
+      keys.push(path);
+    }
+  }
+  return keys;
+}
+
+function loadIgnoreList() {
+  if (!existsSync(IGNORE_FILE)) {
+    return { ignoreMissingKeys: {}, ignoreExtraKeys: {} };
+  }
+  const parsed = readJson(IGNORE_FILE);
+  return {
+    ignoreMissingKeys: parsed.ignoreMissingKeys ?? {},
+    ignoreExtraKeys: parsed.ignoreExtraKeys ?? {},
+  };
+}
+
+function discoverLocaleFiles() {
+  return readdirSync(MESSAGES_DIR)
+    .filter((name) => name.endsWith(".json") && name !== "i18n-ignore.json")
+    .map((name) => ({
+      locale: name.replace(/\.json$/, ""),
+      filePath: path.join(MESSAGES_DIR, name),
+    }));
+}
+
+function main() {
+  const localeFiles = discoverLocaleFiles();
+  const baseFile = localeFiles.find((f) => f.locale === BASE_LOCALE);
+
+  if (!baseFile) {
+    console.error(`i18n check: base locale "${BASE_LOCALE}" not found in ${MESSAGES_DIR}`);
+    process.exit(1);
+  }
+
+  const baseKeys = new Set(flattenKeys(readJson(baseFile.filePath)));
+  const { ignoreMissingKeys, ignoreExtraKeys } = loadIgnoreList();
+
+  let hasFailures = false;
+
+  for (const { locale, filePath } of localeFiles) {
+    if (locale === BASE_LOCALE) continue;
+
+    const localeKeys = new Set(flattenKeys(readJson(filePath)));
+    const ignoredMissing = new Set(ignoreMissingKeys[locale] ?? []);
+    const ignoredExtra = new Set(ignoreExtraKeys[locale] ?? []);
+
+    const missing = [...baseKeys]
+      .filter((key) => !localeKeys.has(key) && !ignoredMissing.has(key))
+      .sort();
+    const extra = [...localeKeys]
+      .filter((key) => !baseKeys.has(key) && !ignoredExtra.has(key))
+      .sort();
+
+    if (missing.length === 0 && extra.length === 0) {
+      console.log(`i18n check: ${locale}.json — OK (${localeKeys.size} keys)`);
+      continue;
+    }
+
+    hasFailures = true;
+    console.error(`i18n check: ${locale}.json — MISMATCH vs ${BASE_LOCALE}.json`);
+    if (missing.length > 0) {
+      console.error(`  Missing (present in ${BASE_LOCALE}.json, absent in ${locale}.json):`);
+      for (const key of missing) console.error(`    - ${key}`);
+    }
+    if (extra.length > 0) {
+      console.error(`  Extra (present in ${locale}.json, absent in ${BASE_LOCALE}.json):`);
+      for (const key of extra) console.error(`    - ${key}`);
+    }
+  }
+
+  if (hasFailures) {
+    console.error(
+      "\ni18n check failed. Add the key to every locale, remove the stray key, " +
+        "or add an explicit exception to frontend/messages/i18n-ignore.json.",
+    );
+    process.exit(1);
+  }
+
+  console.log("i18n check: all locales match.");
+}
+
+main();

--- a/frontend/src/components/create/CreateSplitWizardLegacy.test.tsx
+++ b/frontend/src/components/create/CreateSplitWizardLegacy.test.tsx
@@ -1,0 +1,125 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useFieldArray, useForm } from "react-hook-form";
+
+import { CreateSplitWizard } from "./CreateSplitWizardLegacy";
+import { findDuplicateCollaboratorAddressIds } from "@/lib/address";
+import type { WalletState } from "@/lib/wallet";
+
+const wallet: WalletState = { connected: false, address: null, network: "testnet" };
+
+interface CreateCollaboratorInput {
+  address: string;
+  alias: string;
+  basisPoints: string;
+}
+
+interface CreateSplitFormValues {
+  projectId: string;
+  title: string;
+  projectType: string;
+  token: string;
+  collaborators: CreateCollaboratorInput[];
+}
+
+function Harness({ collaborators }: { collaborators: CreateCollaboratorInput[] }) {
+  const { control, register, handleSubmit } = useForm<CreateSplitFormValues>({
+    defaultValues: {
+      projectId: "",
+      title: "",
+      projectType: "music",
+      token: "",
+      collaborators,
+    },
+  });
+  const { fields, append, remove } = useFieldArray({ control, name: "collaborators" });
+
+  const collaboratorValidationErrors: Record<string, string> = {};
+  const duplicateIds = findDuplicateCollaboratorAddressIds(
+    fields.map((field, index) => ({ id: field.id, address: collaborators[index]?.address ?? "" })),
+  );
+  duplicateIds.forEach((id) => {
+    collaboratorValidationErrors[id] = "Duplicate address";
+  });
+
+  return (
+    <CreateSplitWizard
+      wallet={wallet}
+      control={control}
+      register={register}
+      handleSubmit={handleSubmit}
+      onSubmit={() => {}}
+      createFormErrors={{}}
+      collaboratorFields={fields}
+      appendCollaborator={append}
+      removeCollaborator={remove}
+      collaboratorValidationErrors={collaboratorValidationErrors}
+      totalBasisPoints={10_000}
+      isValid={false}
+      sorobanSplitFlowBusy={false}
+      isSubmitting={false}
+      receipt={null}
+      latestTxHash={null}
+      createdProject={null}
+      setActiveTab={() => {}}
+      setSearchProjectId={() => {}}
+      setFetchedProject={() => {}}
+    />
+  );
+}
+
+describe("CreateSplitWizard duplicate collaborator validation", () => {
+  it("shows no duplicate errors when addresses are distinct", () => {
+    render(
+      <Harness
+        collaborators={[
+          { address: "GABC111", alias: "A", basisPoints: "5000" },
+          { address: "GDEF222", alias: "B", basisPoints: "5000" },
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText(/duplicate address/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a field-level error on every entry sharing an exact duplicate address", () => {
+    render(
+      <Harness
+        collaborators={[
+          { address: "GABC111", alias: "A", basisPoints: "5000" },
+          { address: "GABC111", alias: "B", basisPoints: "5000" },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText(/duplicate address/i)).toHaveLength(2);
+  });
+
+  it("flags duplicates that differ only by casing", () => {
+    render(
+      <Harness
+        collaborators={[
+          { address: "gabc111", alias: "A", basisPoints: "5000" },
+          { address: "GABC111", alias: "B", basisPoints: "5000" },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText(/duplicate address/i)).toHaveLength(2);
+  });
+
+  it("flags duplicates that differ only by surrounding whitespace", () => {
+    render(
+      <Harness
+        collaborators={[
+          { address: "  GABC111", alias: "A", basisPoints: "5000" },
+          { address: "GABC111  ", alias: "B", basisPoints: "5000" },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText(/duplicate address/i)).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/split-app-legacy.tsx
+++ b/frontend/src/components/split-app-legacy.tsx
@@ -31,7 +31,7 @@ import {
   buildUnpauseDistributionsXdr,
   type AdminStatusState,
 } from "@/lib/api";
-import { isOwner } from "@/lib/address";
+import { isOwner, findDuplicateCollaboratorAddressIds, type CollaboratorAddressEntry } from "@/lib/address";
 import {
   createSorobanRpcServer,
   signWithWallet,
@@ -228,33 +228,26 @@ export function SplitApp({
 
   const collaboratorValidationErrors = useMemo(() => {
     const errors: Record<string, string> = {};
-    const addresses = new Map<string, string>();
-    const duplicates = new Set<string>();
+    const validEntries: CollaboratorAddressEntry[] = [];
 
     collaboratorFields.forEach((field, index) => {
       const collaborator = watchedCollaborators[index];
       if (!collaborator) return;
 
       const addr = collaborator.address.trim();
-      if (addr) {
-        if (!StrKey.isValidEd25519PublicKey(addr) && !StrKey.isValidContract(addr)) {
-          errors[field.id] = "Invalid Stellar address (G...) or contract ID (C...)";
-        } else if (addresses.has(addr)) {
-          duplicates.add(addr);
-        } else {
-          addresses.set(addr, field.id);
-        }
+      if (!addr) return;
+
+      if (!StrKey.isValidEd25519PublicKey(addr) && !StrKey.isValidContract(addr)) {
+        errors[field.id] = "Invalid Stellar address (G...) or contract ID (C...)";
+      } else {
+        validEntries.push({ id: field.id, address: addr });
       }
     });
 
-    if (duplicates.size > 0) {
-      collaboratorFields.forEach((field, index) => {
-        const addr = watchedCollaborators[index]?.address.trim();
-        if (addr && duplicates.has(addr)) {
-          errors[field.id] = "Duplicate address";
-        }
-      });
-    }
+    const duplicateIds = findDuplicateCollaboratorAddressIds(validEntries);
+    duplicateIds.forEach((id) => {
+      errors[id] = "Duplicate address";
+    });
 
     return errors;
   }, [collaboratorFields, watchedCollaborators]);

--- a/frontend/src/lib/address.test.ts
+++ b/frontend/src/lib/address.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isOwner } from "./address";
+import {
+  findDuplicateCollaboratorAddressIds,
+  isOwner,
+  normalizeStellarAddress,
+} from "./address";
 
 describe("isOwner", () => {
   it("returns true for matching addresses", () => {
@@ -18,5 +22,75 @@ describe("isOwner", () => {
   it("returns false when connected address is null or undefined", () => {
     expect(isOwner("GABC123", null)).toBe(false);
     expect(isOwner("GABC123", undefined)).toBe(false);
+  });
+});
+
+describe("normalizeStellarAddress", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeStellarAddress("  GABC123  ")).toBe("GABC123");
+  });
+
+  it("uppercases the address", () => {
+    expect(normalizeStellarAddress("gabc123")).toBe("GABC123");
+  });
+
+  it("handles mixed casing and whitespace together", () => {
+    expect(normalizeStellarAddress("  gAbC123\n")).toBe("GABC123");
+  });
+
+  it("returns an empty string for blank input", () => {
+    expect(normalizeStellarAddress("   ")).toBe("");
+  });
+});
+
+describe("findDuplicateCollaboratorAddressIds", () => {
+  it("returns an empty set when there are no duplicates", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "GABC111" },
+      { id: "b", address: "GDEF222" },
+    ]);
+    expect(result.size).toBe(0);
+  });
+
+  it("flags both entries on an exact duplicate", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "GABC111" },
+      { id: "b", address: "GABC111" },
+    ]);
+    expect(result).toEqual(new Set(["a", "b"]));
+  });
+
+  it("flags duplicates that differ only by casing", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "gabc111" },
+      { id: "b", address: "GABC111" },
+    ]);
+    expect(result).toEqual(new Set(["a", "b"]));
+  });
+
+  it("flags duplicates that differ only by surrounding whitespace", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "  GABC111" },
+      { id: "b", address: "GABC111  " },
+    ]);
+    expect(result).toEqual(new Set(["a", "b"]));
+  });
+
+  it("flags every entry when more than two share an address", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "GABC111" },
+      { id: "b", address: " gabc111 " },
+      { id: "c", address: "GABC111" },
+      { id: "d", address: "GDEF222" },
+    ]);
+    expect(result).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("ignores empty addresses", () => {
+    const result = findDuplicateCollaboratorAddressIds([
+      { id: "a", address: "" },
+      { id: "b", address: "   " },
+    ]);
+    expect(result.size).toBe(0);
   });
 });

--- a/frontend/src/lib/address.ts
+++ b/frontend/src/lib/address.ts
@@ -5,3 +5,44 @@ export function isOwner(projectOwnerAddress: string, connectedAddress?: string |
 
   return projectOwnerAddress.toLowerCase() === connectedAddress.toLowerCase();
 }
+
+/**
+ * Normalizes a Stellar address for comparison: collapses/trims surrounding
+ * whitespace and uppercases it, since valid StrKey addresses are case-sensitive
+ * uppercase but users may paste values with stray whitespace or wrong casing.
+ */
+export function normalizeStellarAddress(address: string): string {
+  return address.trim().toUpperCase();
+}
+
+export interface CollaboratorAddressEntry {
+  id: string;
+  address: string;
+}
+
+/**
+ * Returns the ids of every collaborator entry whose address (after
+ * normalization) is shared with at least one other entry. Empty addresses
+ * are ignored - required-field validation handles those separately.
+ */
+export function findDuplicateCollaboratorAddressIds(
+  entries: CollaboratorAddressEntry[],
+): Set<string> {
+  const firstIdByAddress = new Map<string, string>();
+  const duplicateIds = new Set<string>();
+
+  for (const entry of entries) {
+    const normalized = normalizeStellarAddress(entry.address);
+    if (!normalized) continue;
+
+    const firstId = firstIdByAddress.get(normalized);
+    if (firstId !== undefined) {
+      duplicateIds.add(firstId);
+      duplicateIds.add(entry.id);
+    } else {
+      firstIdByAddress.set(normalized, entry.id);
+    }
+  }
+
+  return duplicateIds;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,7 @@
                 "lucide-react": "^0.536.0",
                 "next": "16.2.6",
                 "next-intl": "^4.9.1",
+                "nprogress": "^0.2.0",
                 "react": "19.2.6",
                 "react-dom": "19.2.6",
                 "react-hook-form": "^7.62.0",
@@ -236,6 +237,7 @@
                 "@testing-library/react": "16.3.2",
                 "@testing-library/user-event": "14.6.1",
                 "@types/node": "25.5.0",
+                "@types/nprogress": "^0.2.3",
                 "@types/react": "19.2.14",
                 "@typescript-eslint/eslint-plugin": "8.60.0",
                 "@typescript-eslint/parser": "8.60.0",
@@ -6963,6 +6965,13 @@
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "license": "MIT"
         },
+        "node_modules/@types/nprogress": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.3.tgz",
+            "integrity": "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/pg": {
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -13639,6 +13648,12 @@
             "bin": {
                 "which": "bin/which"
             }
+        },
+        "node_modules/nprogress": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+            "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+            "license": "MIT"
         },
         "node_modules/object-assign": {
             "version": "4.1.1",


### PR DESCRIPTION
## Summary

Four independent hardening/quality issues bundled into one branch, following this repo's existing convention of grouping issue numbers per PR.

### #869 — Frontend: duplicate collaborator address validation
- Duplicate detection now normalizes addresses (trim + uppercase) before comparing, so casing- and whitespace-only duplicates are caught, not just exact string matches.
- Extracted into pure, tested helpers: `normalizeStellarAddress` / `findDuplicateCollaboratorAddressIds` in `frontend/src/lib/address.ts`.
- Field-level errors already existed in `CreateSplitWizard`; wired the new logic through.
- Backend validation (`schemas/splits.ts`) remains the source of truth — this is client-side UX only.
- New tests: `address.test.ts` (casing/whitespace/exact-duplicate cases) + new `CreateSplitWizardLegacy.test.tsx` (renders the wizard and asserts field-level errors on duplicates).

### #870 — CI/CD: workflow permissions audit
- Reviewed all 12 workflow files' `permissions:` blocks.
- `smoke-testnet.yml` had **no `permissions:` block at all** (fell back to default token permissions) — added `contents: read`.
- `contract-testnet-deploy.yml` and `release.yml` had `contents: write` at workflow level for a single job — moved to job-level with an inline comment explaining the exception (pushing deploy config / creating a release).
- Added a permissions audit table and a periodic checklist to `docs/runbooks/cicd-security.md`.

### #871 — API documentation: OpenAPI examples
- Added request/response examples (success + common validation errors) for create, deposit (fund), distribute, update-collaborators, and list-history.
- Registered the previously **undocumented** `/events` and `/events/transactions/{txHash}` SSE endpoints, with example event frames mirrored from the existing SSE tests.
- Wired the `adminApiKey` security scheme (defined but never referenced) onto all `/splits/admin/*` operations.
- Fixed `generate:openapi` to write to `docs/openapi.yaml` (now committed) and added a drift-check test (`openapi.test.ts`) that regenerates the spec and diffs it against the committed file — runs automatically via `npm run test -w backend`.

### #872 — Frontend i18n: CI key-parity check
- New `frontend/scripts/check-i18n-keys.mjs` flattens and diffs every locale's message keys against `en.json`, failing on missing or extra keys.
- Opt-in escape hatch via `messages/i18n-ignore.json` for intentional per-locale exceptions.
- Added `check:i18n` npm script and wired it into `ci.yml`, `frontend-ci.yml`, and `frontend-quality.yml`.
- Documented the workflow for adding new translation keys in `frontend/README.md`.

### Incidental fix
- `package-lock.json` was out of sync with `frontend/package.json` (missing `nprogress`/`@types/nprogress`), which would break `npm ci` — resynced while installing deps to validate this branch.

## Test plan
- [x] `address.test.ts` + `CreateSplitWizardLegacy.test.tsx` — 18/18 passing
- [x] `backend/src/__tests__/openapi.test.ts` — spec validates via `SwaggerParser` and matches committed `docs/openapi.yaml`
- [x] `node frontend/scripts/check-i18n-keys.mjs` — passes on current locales; manually verified it fails on injected missing/extra keys and respects `i18n-ignore.json`
- [x] All edited workflow YAML validated with a YAML parser
- [ ] CI (this PR) — data-integrity/frontend/backend/security-audit/contracts jobs

Closes #869
Closes #870
Closes #871
Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)