### PR TITLE
[#860] Add frontend SSE fallback to polling for transaction status

### DIFF
--- a/frontend/src/hooks/useTransactionStatus.test.ts
+++ b/frontend/src/hooks/useTransactionStatus.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTransactionStatus } from "./useTransactionStatus";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+}
+
+describe("useTransactionStatus", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource as unknown as typeof EventSource);
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("uses SSE updates when the stream succeeds", async () => {
+    const { result } = renderHook(() => useTransactionStatus("tx-sse-success", true));
+
+    expect(result.current.status).toBe("pending");
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.url).toContain("/api/events/transactions/tx-sse-success");
+
+    act(() => {
+      MockEventSource.instances[0]?.onmessage?.({
+        data: JSON.stringify({
+          status: "completed",
+          record: {
+            txHash: "tx-sse-success",
+            projectId: "project-1",
+            action: "create",
+            amount: "100",
+            createdAt: new Date().toISOString(),
+          },
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("completed");
+      expect(result.current.record?.txHash).toBe("tx-sse-success");
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to polling after SSE connection errors and recovers", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: "completed",
+          txHash: "tx-fallback",
+          projectId: "project-2",
+          action: "create",
+          amount: "250",
+          createdAt: new Date().toISOString(),
+        }),
+      } as Response);
+
+    const { result } = renderHook(() => useTransactionStatus("tx-fallback", true));
+
+    act(() => {
+      MockEventSource.instances[0]?.onerror?.(new Error("socket dropped"));
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("completed");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(result.current.record?.txHash).toBe("tx-fallback");
+    });
+  });
+
+  it("falls back to polling when EventSource is unavailable", async () => {
+    vi.stubGlobal("EventSource", undefined as unknown as typeof EventSource);
+
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: "completed",
+        txHash: "tx-no-sse",
+        projectId: "project-3",
+        action: "create",
+        amount: "300",
+        createdAt: new Date().toISOString(),
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useTransactionStatus("tx-no-sse", true));
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("completed");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result.current.record?.txHash).toBe("tx-no-sse");
+    });
+  });
+});

--- a/frontend/src/hooks/useTransactionStatus.ts
+++ b/frontend/src/hooks/useTransactionStatus.ts
@@ -2,6 +2,9 @@
 
 import { useEffect, useState, useRef } from "react";
 
+const MAX_POLL_ATTEMPTS = 6;
+const BASE_POLL_DELAY_MS = 500;
+
 interface TransactionRecord {
   txHash: string;
   projectId: string;
@@ -32,9 +35,76 @@ export function useTransactionStatus(
   const [record, setRecord] = useState<TransactionRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const clearPollTimer = () => {
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+
+    const closeEventSource = () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+    };
+
+    const pollForStatus = async (attempt = 0): Promise<void> => {
+      if (!txHash || cancelled) return;
+
+      try {
+        const response = await fetch(`/api/transactions/${encodeURIComponent(txHash)}`);
+        if (cancelled) return;
+
+        if (response.ok) {
+          const payload = (await response.json()) as
+            | (TransactionRecord & { status?: string; message?: string })
+            | null;
+
+          const normalizedStatus = String(payload?.status ?? "").toLowerCase();
+
+          if (normalizedStatus === "completed" || normalizedStatus === "success") {
+            setStatus("completed");
+            setRecord(payload as TransactionRecord);
+            setError(null);
+            return;
+          }
+
+          if (normalizedStatus === "failed" || normalizedStatus === "error") {
+            setStatus("error");
+            setError(payload?.message ?? "Transaction failed");
+            return;
+          }
+        }
+      } catch {
+        // Continue retrying with backoff on transient network errors.
+      }
+
+      if (attempt >= MAX_POLL_ATTEMPTS) {
+        setStatus("timeout");
+        setError("Timed out waiting for transaction confirmation");
+        return;
+      }
+
+      const delay = Math.min(BASE_POLL_DELAY_MS * 2 ** attempt, 5_000);
+      pollTimerRef.current = setTimeout(() => {
+        void pollForStatus(attempt + 1);
+      }, delay);
+    };
+
+    const startPollingFallback = () => {
+      closeEventSource();
+      void pollForStatus();
+    };
+
     if (!txHash || !enabled) {
+      closeEventSource();
+      clearPollTimer();
       setStatus(null);
       setRecord(null);
       setError(null);
@@ -44,9 +114,13 @@ export function useTransactionStatus(
     // Check if EventSource is supported
     if (typeof EventSource === "undefined") {
       console.warn("EventSource not supported, falling back to polling");
-      setStatus("error");
-      setError("Real-time updates not supported in this browser");
-      return;
+      setStatus("pending");
+      setError(null);
+      startPollingFallback();
+      return () => {
+        cancelled = true;
+        clearPollTimer();
+      };
     }
 
     setStatus("pending");
@@ -60,41 +134,50 @@ export function useTransactionStatus(
 
     eventSource.onmessage = (event) => {
       try {
-        const data: TransactionStatusEvent = JSON.parse(event.data);
+        const data = JSON.parse(event.data) as
+          | TransactionStatusEvent
+          | (TransactionRecord & { status?: string });
 
-        if (data.status === "completed" && data.record) {
+        if (
+          (data as TransactionStatusEvent).status === "completed" &&
+          (data as TransactionStatusEvent).record
+        ) {
           setStatus("completed");
-          setRecord(data.record);
+          setRecord((data as TransactionStatusEvent).record ?? null);
           eventSource.close();
-        } else if (data.status === "error") {
+        } else if ((data as TransactionStatusEvent).status === "error") {
           setStatus("error");
-          setError(data.message || "Unknown error occurred");
+          setError((data as TransactionStatusEvent).message || "Unknown error occurred");
           eventSource.close();
-        } else if (data.status === "timeout") {
+        } else if ((data as TransactionStatusEvent).status === "timeout") {
           setStatus("timeout");
+          eventSource.close();
+        } else if (
+          data &&
+          typeof data === "object" &&
+          "txHash" in data
+        ) {
+          // Backend SSE may emit the transaction record directly.
+          setStatus("completed");
+          setRecord(data as TransactionRecord);
           eventSource.close();
         }
       } catch (err) {
         console.error("Failed to parse SSE event:", err);
-        setStatus("error");
-        setError("Failed to parse server response");
-        eventSource.close();
+        startPollingFallback();
       }
     };
 
     eventSource.onerror = (err) => {
       console.error("SSE connection error:", err);
-      setStatus("error");
-      setError("Connection to server lost");
-      eventSource.close();
+      startPollingFallback();
     };
 
     // Cleanup on unmount or when txHash changes
     return () => {
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
-        eventSourceRef.current = null;
-      }
+      cancelled = true;
+      closeEventSource();
+      clearPollTimer();
     };
   }, [txHash, enabled]);
 


### PR DESCRIPTION
Closes #860

Adds SSE fallback polling with exponential backoff in useTransactionStatus.
Handles SSE disconnects, unsupported EventSource, and direct record payloads.
Stops polling when terminal status is reached.

Tested:
- frontend: vitest src/hooks/useTransactionStatus.test.ts