### PR TITLE
[#346] # Align role model with frontend personas (company/customer) and add Driver role

### DIFF
--- a/backend/src/__tests__/users.test.ts
+++ b/backend/src/__tests__/users.test.ts
@@ -7,6 +7,7 @@ import { requestIdMiddleware } from "../middleware/request-id.js";
 import { signToken } from "../services/jwt.js";
 
 const findOneMock = vi.fn();
+const existMock = vi.fn();
 const createMock = vi.fn();
 const saveMock = vi.fn();
 const commitMock = vi.fn();
@@ -17,6 +18,7 @@ vi.mock("../services/database.js", () => ({
   getDataSource: () => ({
     getRepository: () => ({
       findOne: findOneMock,
+      exist: existMock,
       create: createMock,
       save: saveMock
     })
@@ -32,6 +34,7 @@ vi.mock("../services/database.js", () => ({
   }) => Promise<unknown>) => {
     const repository = {
       findOne: findOneMock,
+      exist: existMock,
       create: createMock,
       save: saveMock
     };
@@ -71,9 +74,10 @@ describe("User Registration API", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     createMock.mockImplementation((input) => input);
+    existMock.mockResolvedValue(false);
     saveMock.mockImplementation(async (input) => ({
       id: "11111111-1111-4111-8111-111111111111",
-      role: "user",
+      role: "customer",
       isActive: true,
       createdAt: NOW,
       updatedAt: NOW,
@@ -91,7 +95,8 @@ describe("User Registration API", () => {
         .send({
           walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
           email: "test@example.com",
-          alias: "TestUser"
+          alias: "TestUser",
+          role: "company"
         });
 
       expect(response.status).toBe(201);
@@ -99,8 +104,22 @@ describe("User Registration API", () => {
       expect(response.body.walletAddress).toBe("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
       expect(response.body.email).toBe("test@example.com");
       expect(response.body.alias).toBe("TestUser");
-      expect(response.body.role).toBe("user");
+      expect(response.body.role).toBe("company");
       expect(response.body.isActive).toBe(true);
+    });
+
+    it("should default to customer role when no persona is provided", async () => {
+      findOneMock.mockResolvedValue(null);
+      const app = createApp();
+
+      const response = await request(app)
+        .post("/users/register")
+        .send({
+          walletAddress: "GBIRMAYQUTHQC762ZTJTNXWDSHSDGN64ZXPXJ6XRLWJCAF6TS4Z7J7IO"
+        });
+
+      expect(response.status).toBe(201);
+      expect(response.body.role).toBe("customer");
     });
 
     it("should register a user without optional fields", async () => {
@@ -119,17 +138,14 @@ describe("User Registration API", () => {
     });
 
     it("should reject duplicate wallet address", async () => {
-      findOneMock.mockResolvedValue({
-        id: "existing-user",
-        walletAddress: "GAFY5DYD3EEUWPHL2JHAWFOLKEI2IAQRAVW4Y3L6DLJQOXG2TAJMU7GC"
-      });
+      existMock.mockResolvedValue(true);
       const app = createApp();
 
       const response = await request(app)
         .post("/users/register")
         .send({ walletAddress: "GAFY5DYD3EEUWPHL2JHAWFOLKEI2IAQRAVW4Y3L6DLJQOXG2TAJMU7GC" });
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(409);
       expect(response.body.error).toBeDefined();
     });
 
@@ -169,7 +185,7 @@ describe("User Registration API", () => {
         walletAddress,
         email: undefined,
         alias: "GetTestUser",
-        role: "user",
+        role: "customer",
         isActive: true,
         createdAt: NOW,
         updatedAt: NOW
@@ -211,7 +227,7 @@ describe("User Registration API", () => {
         walletAddress,
         email: "test@example.com",
         alias: "LoginUser",
-        role: "user",
+        role: "driver",
         isActive: true,
         createdAt: NOW,
         updatedAt: NOW
@@ -298,7 +314,7 @@ describe("User Registration API", () => {
         walletAddress,
         email: "old@example.com",
         alias: "OldAlias",
-        role: "user",
+        role: "customer",
         isActive: true,
         createdAt,
         updatedAt: updatedAtBefore
@@ -309,7 +325,7 @@ describe("User Registration API", () => {
         walletAddress,
         email: "new@example.com",
         alias: "NewAlias",
-        role: "user",
+        role: "customer",
         isActive: true,
         createdAt,
         updatedAt: updatedAtAfter
@@ -359,7 +375,7 @@ describe("User Registration API", () => {
         walletAddress,
         email: "me@test.com",
         alias: "MeUser",
-        role: "user",
+        role: "customer",
         isActive: true,
         createdAt: NOW,
         updatedAt: NOW
@@ -375,7 +391,7 @@ describe("User Registration API", () => {
       expect(response.body.walletAddress).toBe(walletAddress);
       expect(response.body.email).toBe("me@test.com");
       expect(response.body.alias).toBe("MeUser");
-      expect(response.body.role).toBe("user");
+      expect(response.body.role).toBe("customer");
     });
 
     it("should return 401 when no auth token is provided", async () => {

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -5,6 +5,8 @@ import {
   CreateDateColumn,
   UpdateDateColumn
 } from "typeorm";
+import { DEFAULT_USER_ROLE } from "../lib/user-roles.js";
+import type { UserRole } from "../lib/user-roles.js";
 
 @Entity("users")
 export class User {
@@ -20,8 +22,8 @@ export class User {
   @Column({ type: "varchar", length: 128, nullable: true })
   alias?: string;
 
-  @Column({ type: "varchar", length: 32, default: "user" })
-  role!: string;
+  @Column({ type: "varchar", length: 32, default: DEFAULT_USER_ROLE })
+  role!: UserRole;
 
   @Column({ type: "boolean", default: true })
   isActive!: boolean;

--- a/backend/src/lib/user-roles.ts
+++ b/backend/src/lib/user-roles.ts
@@ -1,0 +1,5 @@
+export const USER_ROLES = ["company", "customer", "driver"] as const;
+
+export type UserRole = (typeof USER_ROLES)[number];
+
+export const DEFAULT_USER_ROLE: UserRole = "customer";

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -23,7 +23,7 @@ export const usersRouter = Router();
  */
 usersRouter.post("/register", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { walletAddress, email, alias } = userRegistrationSchema.parse(req.body);
+    const { walletAddress, email, alias, role } = userRegistrationSchema.parse(req.body);
 
     // Get repository without opening a transaction
     const dataSource = getDataSource();
@@ -49,7 +49,7 @@ usersRouter.post("/register", async (req: Request, res: Response, next: NextFunc
         walletAddress,
         email,
         alias,
-        role: "user",
+        role,
         isActive: true,
       });
 

--- a/backend/src/schemas/user.schemas.ts
+++ b/backend/src/schemas/user.schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { StrKey } from "@stellar/stellar-sdk";
+import { DEFAULT_USER_ROLE, USER_ROLES } from "../lib/user-roles.js";
 
 // Stellar address validator
 export const stellarAddressSchema = z
@@ -14,6 +15,7 @@ export const userRegistrationSchema = z.object({
   walletAddress: stellarAddressSchema,
   email: z.string().email("Invalid email format").optional(),
   alias: z.string().min(1, "Alias is required").max(64, "Alias must be at most 64 characters").optional(),
+  role: z.enum(USER_ROLES).default(DEFAULT_USER_ROLE),
 });
 
 
@@ -23,7 +25,7 @@ export const userResponseSchema = z.object({
   walletAddress: z.string(),
   email: z.string().optional(),
   alias: z.string().optional(),
-  role: z.string(),
+  role: z.enum(USER_ROLES),
   isActive: z.boolean(),
   createdAt: z.string(),
   updatedAt: z.string(),


### PR DESCRIPTION
Closes #346

Aligned backend user role model with frontend personas.
Added canonical roles: company, customer, driver.
Registration now accepts role and defaults to customer.
Updated user route tests to cover explicit and default personas.
Tested: backend users route tests pass.