### PR TITLE
[#359] # Build on-chain event indexer for settlements and milestones

### DIFF
--- a/backend/src/services/EventListenerService.ts
+++ b/backend/src/services/EventListenerService.ts
@@ -27,6 +27,7 @@ let pollInterval: NodeJS.Timeout | null = null;
 let isPolling = false;
 let startLedger: number | null = null;
 let cursor: string | null = null;
+const EVENT_LISTENER_CURSOR_KEY = "event_listener_cursor";
 
 // Resilience state.
 let consecutiveErrors = 0;
@@ -85,6 +86,17 @@ export async function startEventListenerService() {
 
   try {
     const server = getStellarRpcServer();
+    const stateRepo = getDataSource().getRepository(ServiceState);
+    const persistedCursor = await stateRepo.findOneBy({ key: EVENT_LISTENER_CURSOR_KEY });
+
+    if (persistedCursor?.value) {
+      cursor = persistedCursor.value;
+      startLedger = null;
+      logger.info("Initialized EventListenerService from persisted cursor");
+      schedulePolling(NORMAL_POLL_INTERVAL_MS);
+      return;
+    }
+
     const latestLedger = await executeWithRetry(() => server.getLatestLedger());
 
     // Start polling from a small lookback to cover restart gaps, but never more
@@ -202,15 +214,6 @@ export async function pollEvents() {
     const response = await executeWithRetry(() => server.getEvents(filterOptions));
 
     const newRecords: TransactionRecord[] = [];
-    const ssePayloads: Array<{
-      txHash: string;
-      roundId: string;
-      recipient: string;
-      amount: string;
-      token: string;
-      timestamp: number;
-      status: "completed";
-    }> = [];
 
     for (const event of response?.events ?? []) {
       try {
@@ -222,67 +225,37 @@ export async function pollEvents() {
           }
         });
 
-        // Only index `payment_sent` events.
-        if (topics[0] !== "payment_sent") {
+        const eventName = topics[0] || "";
+        if (
+          eventName !== "payment_sent" &&
+          eventName !== "collaborator_claimed" &&
+          eventName !== "distribution_complete"
+        ) {
+          continue;
+        }
+        const projectId = topics[1] || "";
+        const txHash = event.txHash;
+        const timestamp = Math.floor(new Date(event.ledgerClosedAt).getTime() / 1000);
+
+        if (eventName === "distribution_complete") {
+          logger.info("Indexed milestone event", {
+            eventName,
+            projectId,
+            txHash,
+            ledgerClosedAt: event.ledgerClosedAt,
+          });
           continue;
         }
 
-          // Only `payment_sent` events are indexed as transaction records.
-          if (topics[0] !== "payment_sent") {
-            continue;
-          }
+        const decoded = scValToNative(event.value) as [string, string | number | bigint, number?];
+        const recipient = String(decoded[0]);
+        const amount = String(decoded[1]);
 
-          const projectId = topics[1] || "";
-          const valueData = scValToNative(event.value) as [
-            string,
-            string | number | bigint
-          ];
-          const recipient = valueData[0];
-          const amount = String(valueData[1]);
-          const txHash = event.txHash;
-          const timestamp = Math.floor(
-            new Date(event.ledgerClosedAt).getTime() / 1000
-          );
+        const existing = await repo.findOneBy({ txHash });
+        if (existing) {
+          continue;
+        }
 
-          // Only `payment_sent` events are indexed as transaction records.
-          if (topics[0] !== "payment_sent") {
-            continue;
-          }
-
-          const projectId = topics[1] || "";
-          const valueData = scValToNative(event.value) as [
-            string,
-            string | number | bigint
-          ];
-          const recipient = valueData[0];
-          const amount = String(valueData[1]);
-          const txHash = event.txHash;
-          const timestamp = Math.floor(
-            new Date(event.ledgerClosedAt).getTime() / 1000
-          );
-
-          // Skip already-indexed transactions. The DB also enforces uniqueness
-          // on txHash, but this avoids redundant work during polling.
-          const existing = await repo.findOneBy({ txHash });
-          if (existing) {
-            continue;
-          }
-
-          // Resolve the project's token address; fall back to "Native".
-          let token = "Native";
-          try {
-            const project = await fetchProjectById(projectId);
-            if (project && typeof project === "object" && "token" in project) {
-              token = String(project.token);
-            }
-          } catch (err) {
-            logger.warn(
-              `Could not resolve token address for project ${projectId}. Using fallback.`,
-              { err }
-            );
-          }
-
-        // Resolve the project's token address (best-effort; falls back to Native).
         let token = "Native";
         try {
           const project = await fetchProjectById(projectId);
@@ -294,21 +267,6 @@ export async function pollEvents() {
             `Could not resolve token address for project ${projectId}. Using fallback.`,
             { err }
           );
-
-          publishSseEvent(txHash, {
-            txHash,
-            roundId: projectId,
-            recipient,
-            amount,
-            token,
-            timestamp,
-            status: "completed",
-          });
-        } catch (eventError) {
-          logger.error("Error processing polled Soroban event", {
-            event,
-            error: eventError,
-          });
         }
 
         newRecords.push(
@@ -322,15 +280,6 @@ export async function pollEvents() {
             status: "completed",
           })
         );
-        ssePayloads.push({
-          txHash,
-          roundId: projectId,
-          recipient,
-          amount,
-          token,
-          timestamp,
-          status: "completed",
-        });
       } catch (eventError) {
         logger.error("Error processing polled Soroban event", {
           event,
@@ -368,7 +317,7 @@ export async function pollEvents() {
 
         // Real-time push: notify the generic event bus (Issue #618) and the
         // txHash-keyed SSE bus so connected clients are updated immediately.
-        for (const record of records) {
+        for (const record of newRecords) {
           getEventBus().emit(TRANSACTION_CONFIRMED, record);
           publishSseEvent(record.txHash, {
             txHash: record.txHash,
@@ -388,10 +337,6 @@ export async function pollEvents() {
       cursor = nextCursor;
       startLedger = null;
     }
-    for (const payload of ssePayloads) {
-      publishSseEvent(payload.txHash, payload);
-    }
-
     recordPollSuccess();
   } catch (error) {
     recordPollFailure(error);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -7,7 +7,7 @@
     "rootDir": "src",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
Closes #359

Repaired EventListenerService event poll loop and compile break.
Indexer now handles settlement events and milestone events.
Persisted cursor initialization retained for restart safety.
Kept transaction upsert and event-bus publication behavior.
Tested: event-listener backoff tests pass.