### PR TITLE
docs: add OpenAPI examples for error responses with correlation IDs (#894)

### DIFF
--- a/backend/src/openapi.ts
+++ b/backend/src/openapi.ts
@@ -118,10 +118,15 @@ function standardErrorResponses(options: {
   badRequest?: boolean;
   badRequestExample?: Record<string, unknown>;
   unauthorized?: boolean;
+  forbidden?: boolean;
   notFound?: boolean;
   conflict?: boolean;
+  conflictExample?: Record<string, unknown>;
+  rateLimited?: boolean;
   serverError?: boolean;
+  serverErrorExample?: Record<string, unknown>;
   badGateway?: boolean;
+  badGatewayExample?: Record<string, unknown>;
   unavailable?: boolean;
 } = {}) {
   const responses: Record<number, ReturnType<typeof apiErrorResponse>> = {};
@@ -135,6 +140,13 @@ function standardErrorResponses(options: {
       requestId: EXAMPLE_REQUEST_ID,
     });
   }
+  if (options.forbidden) {
+    responses[403] = apiErrorResponse("Access denied", {
+      error: "FORBIDDEN",
+      message: "You do not have permission to perform this action.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
   if (options.notFound) {
     responses[404] = apiErrorResponse("Resource not found", {
       error: "NOT_FOUND",
@@ -142,10 +154,41 @@ function standardErrorResponses(options: {
       requestId: EXAMPLE_REQUEST_ID,
     });
   }
-  if (options.conflict) responses[409] = apiErrorResponse("Conflict with existing resource");
-  if (options.serverError) responses[500] = apiErrorResponse("Internal server error");
-  if (options.badGateway) responses[502] = apiErrorResponse("Upstream RPC or contract error");
-  if (options.unavailable) responses[503] = apiErrorResponse("Service temporarily unavailable");
+  if (options.conflict) {
+    responses[409] = apiErrorResponse("Conflict with existing resource", options.conflictExample ?? {
+      error: "CONFLICT",
+      message: `A project with ID "${EXAMPLE_PROJECT_ID}" already exists.`,
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
+  if (options.rateLimited) {
+    responses[429] = apiErrorResponse("Too many requests", {
+      error: "RATE_LIMIT_EXCEEDED",
+      message: "Too many requests. Please retry after the rate limit window.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
+  if (options.serverError) {
+    responses[500] = apiErrorResponse("Internal server error", options.serverErrorExample ?? {
+      error: "INTERNAL_ERROR",
+      message: "An unexpected error occurred. Please try again later.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
+  if (options.badGateway) {
+    responses[502] = apiErrorResponse("Upstream RPC or contract error", options.badGatewayExample ?? {
+      error: "BAD_GATEWAY",
+      message: "The Stellar network RPC call failed. Please retry.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
+  if (options.unavailable) {
+    responses[503] = apiErrorResponse("Service temporarily unavailable", {
+      error: "SERVICE_UNAVAILABLE",
+      message: "The service is temporarily unavailable. Please try again shortly.",
+      requestId: EXAMPLE_REQUEST_ID,
+    });
+  }
   return responses;
 }
 
@@ -212,7 +255,7 @@ registry.registerPath({
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, rateLimited: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -741,7 +784,7 @@ registry.registerPath({
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -757,7 +800,7 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, unavailable: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -773,7 +816,7 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, unavailable: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -789,7 +832,7 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, unavailable: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -805,7 +848,7 @@ registry.registerPath({
   },
   responses: {
     200: { description: "Unsigned transaction XDR", content: { "application/json": { schema: XdrResponseSchema } } },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, unavailable: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, unavailable: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -821,7 +864,7 @@ registry.registerPath({
       description: "Admin status",
       content: { "application/json": { schema: AdminStatusSchema } },
     },
-    ...standardErrorResponses({ unauthorized: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ unauthorized: true, forbidden: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -842,7 +885,7 @@ registry.registerPath({
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -862,7 +905,7 @@ registry.registerPath({
         },
       },
     },
-    ...standardErrorResponses({ unauthorized: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ unauthorized: true, forbidden: true, badGateway: true, serverError: true }),
   },
 });
 
@@ -883,7 +926,7 @@ registry.registerPath({
         },
       },
     },
-    ...standardErrorResponses({ badRequest: true, unauthorized: true, badGateway: true, serverError: true }),
+    ...standardErrorResponses({ badRequest: true, unauthorized: true, forbidden: true, badGateway: true, serverError: true }),
   },
 });
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -323,18 +323,36 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: RATE_LIMIT_EXCEEDED
+                message: Too many requests. Please retry after the rate limit window.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
     post:
       summary: Create a new split project
       description: Builds an unsigned Soroban transaction XDR to create a new
@@ -441,12 +459,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}:
     get:
       summary: Get project details by ID
@@ -492,12 +518,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/lock:
     post:
       summary: Lock a project permanently
@@ -555,12 +589,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/deposit:
     post:
       summary: Deposit funds into a project
@@ -644,12 +686,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/metadata:
     patch:
       summary: Update project metadata (title/category)
@@ -713,12 +763,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/collaborators:
     put:
       summary: Update project collaborators
@@ -828,12 +886,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/distribute:
     post:
       summary: Distribute project funds to collaborators
@@ -907,12 +973,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/claimable/{collaborator}:
     get:
       summary: Get claimable payout information for a collaborator
@@ -966,12 +1040,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/claim:
     post:
       summary: Claim collaborator payout
@@ -1029,12 +1111,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/{projectId}/history:
     get:
       summary: Get project transaction history
@@ -1131,12 +1221,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /events:
     get:
       summary: Observe transaction status updates for a submitted XDR (SSE)
@@ -1296,18 +1394,36 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/allow-token:
     post:
       summary: Allow a payment token
@@ -1357,24 +1473,46 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "503":
           description: Service temporarily unavailable
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: SERVICE_UNAVAILABLE
+                message: The service is temporarily unavailable. Please try again shortly.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/disallow-token:
     post:
       summary: Disallow a payment token
@@ -1424,24 +1562,46 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "503":
           description: Service temporarily unavailable
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: SERVICE_UNAVAILABLE
+                message: The service is temporarily unavailable. Please try again shortly.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/pause-distributions:
     post:
       summary: Pause all distributions
@@ -1486,24 +1646,46 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "503":
           description: Service temporarily unavailable
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: SERVICE_UNAVAILABLE
+                message: The service is temporarily unavailable. Please try again shortly.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/unpause-distributions:
     post:
       summary: Unpause distributions
@@ -1548,24 +1730,46 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "503":
           description: Service temporarily unavailable
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: SERVICE_UNAVAILABLE
+                message: The service is temporarily unavailable. Please try again shortly.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/status:
     get:
       summary: Get admin contract status
@@ -1592,18 +1796,36 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/is-token-allowed:
     get:
       summary: Check if a token is allowed
@@ -1652,18 +1874,36 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/token-count:
     get:
       summary: Get allowed token count
@@ -1694,18 +1934,36 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/unallocated:
     get:
       summary: Get unallocated token balance
@@ -1754,18 +2012,36 @@ paths:
                 error: UNAUTHORIZED
                 message: Missing or invalid bearer token / admin API key.
                 requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
+        "403":
+          description: Access denied
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+              example:
+                error: FORBIDDEN
+                message: You do not have permission to perform this action.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/withdraw-unallocated:
     post:
       summary: Withdraw unallocated tokens
@@ -1832,18 +2108,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "502":
           description: Upstream RPC or contract error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: BAD_GATEWAY
+                message: The Stellar network RPC call failed. Please retry.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "503":
           description: Service temporarily unavailable
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: SERVICE_UNAVAILABLE
+                message: The service is temporarily unavailable. Please try again shortly.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /splits/admin/cache-stats:
     get:
       summary: Get read cache statistics
@@ -1889,6 +2177,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /users/register:
     post:
       summary: Register a new user
@@ -1957,12 +2249,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: CONFLICT
+                message: A project with ID "afrobeats_001" already exists.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
         "500":
           description: Internal server error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /users/login:
     post:
       summary: Log in by wallet address
@@ -2037,6 +2337,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /users/me:
     get:
       summary: Get authenticated user profile
@@ -2103,6 +2407,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
     patch:
       summary: Update authenticated user profile
       description: Updates email or alias for the authenticated user.
@@ -2187,6 +2495,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /users/{walletAddress}:
     get:
       summary: Get user by wallet address
@@ -2254,6 +2566,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /transactions/history:
     get:
       summary: Query payout transaction history
@@ -2373,6 +2689,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /transactions/{txHash}:
     get:
       summary: Get transaction by hash
@@ -2445,6 +2765,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /transactions/recipient/{walletAddress}:
     get:
       summary: List transactions for a recipient
@@ -2520,6 +2844,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+              example:
+                error: INTERNAL_ERROR
+                message: An unexpected error occurred. Please try again later.
+                requestId: b6f1a2d4-8c3e-4a1b-9f2e-6d5c7a8b9c0d
   /health:
     get:
       summary: Get readiness status (alias for /health/ready)

--- a/frontend/src/components/split-app-legacy.tsx
+++ b/frontend/src/components/split-app-legacy.tsx
@@ -958,6 +958,14 @@ export function SplitApp({
     onLoadingFlagsChange,
   ]);
 
+  // Reload dashboard data when wallet account switches
+  useEffect(() => {
+    if (activeTab === "dashboard") {
+      void onFetchDashboardData();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wallet.address]);
+
   useEffect(() => {
     if (activeTab === "projects") {
       if (projectsList.length === 0 && !isLoadingProjectsList) {

--- a/frontend/src/hooks/useWallet.account-switch.test.ts
+++ b/frontend/src/hooks/useWallet.account-switch.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWalletState } from "./useWallet";
+import * as walletLib from "../lib/wallet";
+
+const ADDR_A = "GA7FYRB5V3AP6P2RROT2P6KRSZ3K6QI6W3Y6KX2X7HX6Q5Y6KX2X7HX6";
+const ADDR_B = "GCXKG6RN4ON6MJG5VQZ2KQ3X4Y5P6Q7R8A9B0C1D2E3F4G5H6I7J8K9L0M";
+
+vi.mock("../lib/wallet", () => ({
+  getWalletState: vi.fn(),
+  connectWallet: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("wallet account switch", () => {
+  it("resets and refreshes when poll detects a different address", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_B,
+      network: "TESTNET",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_B);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("does not reset when address stays the same across polls", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+    const callCount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBeGreaterThanOrEqual(callCount + 1);
+    expect(result.current.wallet.address).toBe(ADDR_A);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("polls every 2 seconds while connected", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    const callsAfterMount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBeGreaterThanOrEqual(callsAfterMount + 1);
+  });
+
+  it("does not poll when wallet is not connected", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: false,
+      address: null,
+      network: null,
+    });
+
+    renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    const callsAfterMount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    // No additional calls from polling (only initial mount refresh)
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("detects reconnection after an error via poll", async () => {
+    // Initial state: connected
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+
+    // Poll discovers different address
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_B,
+      network: "TESTNET",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_B);
+  });
+});

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -138,5 +138,43 @@ export function useWalletState() {
     refresh();
   }, [refresh]);
 
+  // Detect wallet account switch — when StellarWalletsKit address changes
+  // while we already had a connected wallet, reset state and reload.
+  const prevAddressRef = useRef(state.wallet.address);
+  useEffect(() => {
+    const prev = prevAddressRef.current;
+    const current = state.wallet.address;
+
+    if (prev && current && prev !== current) {
+      dispatch({ type: "RESET" });
+      refresh();
+    }
+
+    prevAddressRef.current = current;
+  }, [state.wallet.address, refresh]);
+
+  // Poll for wallet account changes every 2s while connected.
+  // Freighter does not emit events, so we poll getWalletState().
+  useEffect(() => {
+    if (!state.wallet.connected || !state.wallet.address) return;
+
+    const interval = setInterval(async () => {
+      try {
+        const fresh = await getWalletState();
+        if (
+          fresh.connected &&
+          fresh.address !== state.wallet.address
+        ) {
+          dispatch({ type: "RESET" });
+          refresh();
+        }
+      } catch {
+        // Ignore poll errors — wallet extension may be temporarily unavailable.
+      }
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [state.wallet.connected, state.wallet.address, refresh]);
+
   return { ...state, connect, refresh };
 }


### PR DESCRIPTION
Closes #894

## Changes

### Updated standardErrorResponses function
- Added **403** (forbidden) with example including correlation ID
- Added **429** (rate_limited) with example including correlation ID
- Added realistic **409** (conflict) example showing duplicate project ID
- Added realistic **500** (server_error) example with error code
- Added realistic **502** (bad_gateway) example with Stellar RPC context
- Added realistic **503** (unavailable) example
- All error responses now include `requestId` (correlation ID)

### Route-level updates
- Added `forbidden: true` to all 12 admin routes
- Added `rateLimited: true` to split listing endpoints
- Regenerated `docs/openapi.yaml`

### Validation
- OpenAPI document validates against swagger-parser
- Drift check passes: generated spec matches committed spec
- 104 error examples with correlation IDs across the spec