### PR TITLE
feat: handle wallet account switch with state reset and data reload (#893)

### DIFF
--- a/frontend/src/components/split-app-legacy.tsx
+++ b/frontend/src/components/split-app-legacy.tsx
@@ -958,6 +958,14 @@ export function SplitApp({
     onLoadingFlagsChange,
   ]);
 
+  // Reload dashboard data when wallet account switches
+  useEffect(() => {
+    if (activeTab === "dashboard") {
+      void onFetchDashboardData();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wallet.address]);
+
   useEffect(() => {
     if (activeTab === "projects") {
       if (projectsList.length === 0 && !isLoadingProjectsList) {

--- a/frontend/src/hooks/useWallet.account-switch.test.ts
+++ b/frontend/src/hooks/useWallet.account-switch.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWalletState } from "./useWallet";
+import * as walletLib from "../lib/wallet";
+
+const ADDR_A = "GA7FYRB5V3AP6P2RROT2P6KRSZ3K6QI6W3Y6KX2X7HX6Q5Y6KX2X7HX6";
+const ADDR_B = "GCXKG6RN4ON6MJG5VQZ2KQ3X4Y5P6Q7R8A9B0C1D2E3F4G5H6I7J8K9L0M";
+
+vi.mock("../lib/wallet", () => ({
+  getWalletState: vi.fn(),
+  connectWallet: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("wallet account switch", () => {
+  it("resets and refreshes when poll detects a different address", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_B,
+      network: "TESTNET",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_B);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("does not reset when address stays the same across polls", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+    const callCount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBeGreaterThanOrEqual(callCount + 1);
+    expect(result.current.wallet.address).toBe(ADDR_A);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("polls every 2 seconds while connected", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    const callsAfterMount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBeGreaterThanOrEqual(callsAfterMount + 1);
+  });
+
+  it("does not poll when wallet is not connected", async () => {
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: false,
+      address: null,
+      network: null,
+    });
+
+    renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    const callsAfterMount = vi.mocked(walletLib.getWalletState).mock.calls.length;
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    // No additional calls from polling (only initial mount refresh)
+    expect(vi.mocked(walletLib.getWalletState).mock.calls.length).toBe(callsAfterMount);
+  });
+
+  it("detects reconnection after an error via poll", async () => {
+    // Initial state: connected
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_A,
+      network: "TESTNET",
+    });
+
+    const { result } = renderHook(() => useWalletState());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_A);
+
+    // Poll discovers different address
+    vi.mocked(walletLib.getWalletState).mockResolvedValue({
+      connected: true,
+      address: ADDR_B,
+      network: "TESTNET",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(result.current.wallet.address).toBe(ADDR_B);
+  });
+});

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -138,5 +138,43 @@ export function useWalletState() {
     refresh();
   }, [refresh]);
 
+  // Detect wallet account switch — when StellarWalletsKit address changes
+  // while we already had a connected wallet, reset state and reload.
+  const prevAddressRef = useRef(state.wallet.address);
+  useEffect(() => {
+    const prev = prevAddressRef.current;
+    const current = state.wallet.address;
+
+    if (prev && current && prev !== current) {
+      dispatch({ type: "RESET" });
+      refresh();
+    }
+
+    prevAddressRef.current = current;
+  }, [state.wallet.address, refresh]);
+
+  // Poll for wallet account changes every 2s while connected.
+  // Freighter does not emit events, so we poll getWalletState().
+  useEffect(() => {
+    if (!state.wallet.connected || !state.wallet.address) return;
+
+    const interval = setInterval(async () => {
+      try {
+        const fresh = await getWalletState();
+        if (
+          fresh.connected &&
+          fresh.address !== state.wallet.address
+        ) {
+          dispatch({ type: "RESET" });
+          refresh();
+        }
+      } catch {
+        // Ignore poll errors — wallet extension may be temporarily unavailable.
+      }
+    }, 2000);
+
+    return () => clearInterval(interval);
+  }, [state.wallet.connected, state.wallet.address, refresh]);
+
   return { ...state, connect, refresh };
 }


### PR DESCRIPTION
Closes #893

## Changes

### Account switch detection (useWallet.ts)
- Added 2-second polling via setInterval that calls getWalletState() while connected
- When poll detects a different wallet address, dispatches RESET then calls refresh()
- Added prevAddressRef effect to detect immediate address changes from connect/refresh
- Poll stops automatically when wallet disconnects

### Data reload (split-app-legacy.tsx)
- Added useEffect watching wallet.address that reloads dashboard data on account switch

### Tests (5 passing)
- polls every 2 seconds while connected
- resets and refreshes when poll detects a different address
- does not reset when address stays the same
- does not poll when disconnected
- detects reconnection after error via poll