### PR TITLE
feat: wire request timeout middleware and add comprehensive tests (#891)

### DIFF
--- a/backend/src/__tests__/timeout.test.ts
+++ b/backend/src/__tests__/timeout.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { requestTimeout } from "../middleware/timeout";
 import type { Request, Response, NextFunction } from "express";
 
-function makeRes(overrides: Partial<Response> = {}): Response {
+function makeRes(overrides: Partial<Response> & { locals?: Record<string, unknown> } = {}): Response {
   const listeners: Record<string, (() => void)[]> = {};
   return {
     headersSent: false,
@@ -10,25 +10,112 @@ function makeRes(overrides: Partial<Response> = {}): Response {
     json: vi.fn().mockReturnThis(),
     on: vi.fn((event: string, cb: () => void) => { (listeners[event] ??= []).push(cb); }),
     emit: (event: string) => listeners[event]?.forEach((cb) => cb()),
+    locals: { requestId: "test-correlation-id" },
     ...overrides,
   } as unknown as Response;
 }
 
 describe("requestTimeout middleware", () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("calls next immediately", () => {
     const next = vi.fn() as unknown as NextFunction;
-    const middleware = requestTimeout(1000);
-    middleware({} as Request, makeRes(), next);
-    expect(next).toHaveBeenCalled();
+    requestTimeout(1000)({} as Request, makeRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it("sends 503 after timeout if headers not sent", () => {
+  it("sends 504 with gateway_timeout error after timeout when headers not sent", () => {
+    const res = makeRes();
+    requestTimeout(50)({} as Request, res, vi.fn() as unknown as NextFunction);
+
+    vi.advanceTimersByTime(60);
+
+    expect(res.status).toHaveBeenCalledWith(504);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "gateway_timeout",
+      message: "Request timed out.",
+      requestId: "test-correlation-id",
+    });
+  });
+
+  it("includes correlation ID (requestId) from res.locals in timeout response", () => {
+    const res = makeRes({ locals: { requestId: "custom-id-123" } });
+    requestTimeout(50)({} as Request, res, vi.fn() as unknown as NextFunction);
+
+    vi.advanceTimersByTime(60);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: "custom-id-123" }),
+    );
+  });
+
+  it("does not send timeout response if headers were already sent", () => {
+    const res = makeRes({ headersSent: true });
+    requestTimeout(50)({} as Request, res, vi.fn() as unknown as NextFunction);
+
+    vi.advanceTimersByTime(60);
+
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("clears timer when response finishes before timeout", () => {
     const res = makeRes();
     const next = vi.fn() as unknown as NextFunction;
-    requestTimeout(100)({} as Request, res, next);
-    vi.advanceTimersByTime(200);
-    expect(res.status).toHaveBeenCalledWith(503);
+    requestTimeout(1000)({} as Request, res, next);
+
+    // Response finishes before timeout
+    res.emit("finish");
+
+    // Advance past the timeout
+    vi.advanceTimersByTime(2000);
+
+    // Timeout callback should not have fired
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("clears timer when response closes before timeout", () => {
+    const res = makeRes();
+    const next = vi.fn() as unknown as NextFunction;
+    requestTimeout(1000)({} as Request, res, next);
+
+    // Connection closes before timeout
+    res.emit("close");
+
+    vi.advanceTimersByTime(2000);
+
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("does not send partial response mixed with timeout body", () => {
+    const res = makeRes();
+
+    // Simulate partial response already sent
+    res.headersSent = true;
+
+    requestTimeout(50)({} as Request, res, vi.fn() as unknown as NextFunction);
+
+    vi.advanceTimersByTime(60);
+
+    // json should not be called because headers were already sent
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("uses default 30s timeout when no argument is passed", () => {
+    const res = makeRes();
+    requestTimeout()({} as Request, res, vi.fn() as unknown as NextFunction);
+
+    // Advance 29s — should not fire
+    vi.advanceTimersByTime(29_000);
+    expect(res.json).not.toHaveBeenCalled();
+
+    // Advance past 30s — should fire
+    vi.advanceTimersByTime(2_000);
+    expect(res.status).toHaveBeenCalledWith(504);
   });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import { eventsRouter } from "./routes/events.js";
 import { errorHandler, notFoundHandler } from "./middleware/error.js";
 import { requestIdMiddleware } from "./middleware/request-id.js";
 import { metricsMiddleware } from "./middleware/metrics.js";
+import { requestTimeout } from "./middleware/timeout.js";
 import {
   globalLimiter,
   readLimiter,
@@ -82,6 +83,7 @@ app.use(cors({ origin: corsOrigin }));
 app.use(express.json({ limit: "1mb" }));
 app.use(requestIdMiddleware);
 app.use(metricsMiddleware);
+app.use(requestTimeout());
 
 app.use(globalLimiter);
 

--- a/backend/src/middleware/timeout.ts
+++ b/backend/src/middleware/timeout.ts
@@ -4,15 +4,21 @@ import { RpcTimeoutError } from "../services/stellar.js";
 const DEFAULT_TIMEOUT_MS = 30_000;
 
 export function requestTimeout(ms = DEFAULT_TIMEOUT_MS) {
-  return (_req: Request, res: Response, next: NextFunction) => {
+  return (req: Request, res: Response, next: NextFunction) => {
     const timer = setTimeout(() => {
       if (!res.headersSent) {
-        res.status(504).json({ error: "gateway_timeout", message: "Request timed out." });
+        const requestId = res.locals.requestId;
+        res.status(504).json({
+          error: "gateway_timeout",
+          message: "Request timed out.",
+          ...(requestId ? { requestId } : {}),
+        });
       }
     }, ms);
 
-    res.on("finish", () => clearTimeout(timer));
-    res.on("close", () => clearTimeout(timer));
+    const clear = () => clearTimeout(timer);
+    res.on("finish", clear);
+    res.on("close", clear);
     next();
   };
 }


### PR DESCRIPTION
Closes #891

## Changes

### Timeout middleware (timeout.ts)
- Now reads requestId from res.locals and includes it in the 504 response body
- Previously returned only { error, message } without correlation ID

### App wiring (index.ts)
- Added app.use(requestTimeout()) after requestId and metrics middleware
- 30-second default timeout for all requests

### Tests (8 passing)
1. calls next immediately
2. sends 504 with gateway_timeout error after timeout
3. includes correlation ID (requestId) in timeout response
4. does not send timeout response if headers were already sent (prevents partial response leak)
5. clears timer when response finishes before timeout
6. clears timer when response closes before timeout
7. does not send partial response mixed with timeout body
8. uses default 30s timeout when no argument passed