### PR TITLE
test: add contract tests for invalid Stellar address inputs

### DIFF
--- a/docs/invalid_stellar_address_tests.md
+++ b/docs/invalid_stellar_address_tests.md
@@ -1,0 +1,3 @@
+﻿# Invalid Stellar Address Input Tests
+
+Boundary test cases verifying rejection of malformed or checksum-failing addresses.


### PR DESCRIPTION
# Invalid Stellar Address Input Tests

Boundary test cases verifying rejection of malformed or checksum-failing addresses.