### PR TITLE
test(backend): strict CORS coverage for allowed/disallowed/missing/de…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,11 @@
 PORT=3001
-# Development default. Production MUST set this to explicit origins (comma-separated).
-# Wildcard (*) is rejected in production. Example: https://app.splitnaira.com,https://splitnaira.com
+# Comma-separated list of browser origins allowed to call this API.
+# - Local development: defaults to http://localhost:3000 if unset.
+# - Production: REQUIRED. Wildcard (*) is rejected at startup - list explicit
+#   origins instead, e.g. https://app.splitnaira.com,https://splitnaira.com
+# CORS credentials (cookies) are never enabled - auth uses a bearer token in
+# the Authorization header, so Access-Control-Allow-Credentials is always
+# omitted regardless of this setting. See docs/backend-deploy.md#cors-configuration.
 CORS_ORIGIN=http://localhost:3000
 
 LOG_LEVEL=info

--- a/backend/src/__tests__/cors.test.ts
+++ b/backend/src/__tests__/cors.test.ts
@@ -2,20 +2,25 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import request from "supertest";
 import express from "express";
 import cors from "cors";
+import { resolveCorsOrigins } from "../config/cors.js";
 
-function buildApp(corsOriginEnv: string | undefined) {
+/**
+ * Builds a minimal Express app wired with the SAME `resolveCorsOrigins`
+ * helper (and the same `credentials: false` decision) that `src/index.ts`
+ * uses in production, so these tests exercise the real CORS logic rather
+ * than a re-implementation of it.
+ */
+function buildApp(env: NodeJS.ProcessEnv) {
   const app = express();
-  const origins = corsOriginEnv
-    ? corsOriginEnv.split(",").map((o) => o.trim()).filter(Boolean)
-    : ["http://localhost:3000"];
-  app.use(cors({ origin: origins.length > 0 ? origins : false }));
+  const origin = resolveCorsOrigins(env);
+  app.use(cors({ origin, credentials: false }));
   app.get("/ping", (_req, res) => res.json({ ok: true }));
   return app;
 }
 
 describe("CORS preflight behaviour", () => {
-  it("allows preflight from an explicitly allowed origin", async () => {
-    const app = buildApp("https://app.splitnaira.com");
+  it("allows preflight from an explicitly allowed production origin", async () => {
+    const app = buildApp({ NODE_ENV: "production", CORS_ORIGIN: "https://app.splitnaira.com" });
     const res = await request(app)
       .options("/ping")
       .set("Origin", "https://app.splitnaira.com")
@@ -26,7 +31,7 @@ describe("CORS preflight behaviour", () => {
   });
 
   it("blocks preflight from an origin not in the allowlist", async () => {
-    const app = buildApp("https://app.splitnaira.com");
+    const app = buildApp({ NODE_ENV: "production", CORS_ORIGIN: "https://app.splitnaira.com" });
     const res = await request(app)
       .options("/ping")
       .set("Origin", "https://evil.example.com")
@@ -37,7 +42,10 @@ describe("CORS preflight behaviour", () => {
   });
 
   it("allows multiple comma-separated origins", async () => {
-    const app = buildApp("https://app.splitnaira.com,https://splitnaira.com");
+    const app = buildApp({
+      NODE_ENV: "production",
+      CORS_ORIGIN: "https://app.splitnaira.com,https://splitnaira.com",
+    });
 
     const res1 = await request(app)
       .options("/ping")
@@ -51,6 +59,76 @@ describe("CORS preflight behaviour", () => {
       .set("Access-Control-Request-Method", "GET");
     expect(res2.headers["access-control-allow-origin"]).toBe("https://splitnaira.com");
   });
+
+  it("allows the local development origin by default when CORS_ORIGIN is unset", async () => {
+    const app = buildApp({ NODE_ENV: "development" });
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "http://localhost:3000")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+  });
+
+  it("does not reflect an arbitrary origin in local development", async () => {
+    const app = buildApp({ NODE_ENV: "development" });
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "https://not-localhost.example.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("serves non-browser requests with no Origin header without CORS headers", async () => {
+    // Simulates curl / server-to-server calls / same-origin requests, which
+    // never send an Origin header. The request itself must still succeed;
+    // it simply carries no CORS headers because none were requested.
+    const app = buildApp({ NODE_ENV: "production", CORS_ORIGIN: "https://app.splitnaira.com" });
+    const res = await request(app).get("/ping");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("never sets Access-Control-Allow-Credentials, even for an allowed origin", async () => {
+    // The API authenticates via a bearer token in the Authorization header
+    // (see middleware/auth-jwt.ts), never cookies, so credentialed CORS is
+    // intentionally disabled everywhere - this must stay false.
+    const app = buildApp({ NODE_ENV: "production", CORS_ORIGIN: "https://app.splitnaira.com" });
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "https://app.splitnaira.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("https://app.splitnaira.com");
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+});
+
+describe("resolveCorsOrigins", () => {
+  it("rejects a wildcard origin in production", () => {
+    expect(() => resolveCorsOrigins({ NODE_ENV: "production", CORS_ORIGIN: "*" })).toThrow(
+      /wildcard.*not allowed in production/i,
+    );
+  });
+
+  it("rejects a wildcard mixed in with explicit origins in production", () => {
+    expect(() =>
+      resolveCorsOrigins({ NODE_ENV: "production", CORS_ORIGIN: "https://app.splitnaira.com,*" }),
+    ).toThrow(/wildcard.*not allowed in production/i);
+  });
+
+  it("allows a wildcard outside production", () => {
+    expect(resolveCorsOrigins({ NODE_ENV: "development", CORS_ORIGIN: "*" })).toEqual(["*"]);
+  });
+
+  it("defaults to the local dev origin when CORS_ORIGIN is unset", () => {
+    expect(resolveCorsOrigins({ NODE_ENV: "development" })).toEqual(["http://localhost:3000"]);
+  });
 });
 
 describe("CORS production env validation", () => {
@@ -63,6 +141,7 @@ describe("CORS production env validation", () => {
     SOROBAN_NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
     CONTRACT_ID: "CBLASIRZ7CUKC7S5IS3VSNMQGKZ5FTRWLHZZXH7H4YG6ZLRFPJF5H2LR",
     SIMULATOR_ACCOUNT: "test_account",
+    PAYMENTS_ADMIN_API_KEY: "test-admin-key",
   };
 
   beforeEach(() => {

--- a/backend/src/config/cors.ts
+++ b/backend/src/config/cors.ts
@@ -1,0 +1,25 @@
+const DEFAULT_DEV_ORIGIN = "http://localhost:3000";
+
+/**
+ * Resolves the CORS origin allowlist from environment variables.
+ *
+ * - `CORS_ORIGIN` unset -> defaults to the local frontend dev server only.
+ * - `CORS_ORIGIN` set -> comma-separated list of explicit allowed origins.
+ * - Wildcard (`*`) is rejected outright in production; `config/env.ts`
+ *   additionally enforces that `CORS_ORIGIN` is present at all in production.
+ */
+export function resolveCorsOrigins(env: NodeJS.ProcessEnv = process.env): string[] | false {
+  const origins = env.CORS_ORIGIN
+    ? env.CORS_ORIGIN.split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : [DEFAULT_DEV_ORIGIN];
+
+  if (env.NODE_ENV === "production" && origins.includes("*")) {
+    throw new Error(
+      "CORS wildcard (*) is not allowed in production. Set CORS_ORIGIN to specific origin(s)."
+    );
+  }
+
+  return origins.length > 0 ? origins : false;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -33,6 +33,7 @@ import {
 } from "./middleware/payments-admin.js";
 import { auditAdminMutationsMiddleware } from "./middleware/audit-log.js";
 import { validateEnv, printEnvDiagnostics } from "./config/env.js";
+import { resolveCorsOrigins } from "./config/cors.js";
 import { initDatabase, closeDatabase } from "./services/database.js";
 import { logger } from "./services/logger.js";
 import {
@@ -46,19 +47,7 @@ export const app = express();
 
 app.disable("x-powered-by");
 
-const corsOrigins = process.env.CORS_ORIGIN
-  ? process.env.CORS_ORIGIN.split(",")
-      .map((origin) => origin.trim())
-      .filter(Boolean)
-  : ["http://localhost:3000"];
-
-if (process.env.NODE_ENV === "production" && corsOrigins.includes("*")) {
-  throw new Error(
-    "CORS wildcard (*) is not allowed in production. Set CORS_ORIGIN to specific origin(s)."
-  );
-}
-
-const corsOrigin = corsOrigins.length > 0 ? corsOrigins : false;
+const corsOrigin = resolveCorsOrigins(process.env);
 
 app.use(
   helmet({
@@ -81,7 +70,10 @@ app.use(
     noSniff: true,
   })
 );
-app.use(cors({ origin: corsOrigin }));
+// Credentials are intentionally disabled: auth uses a bearer token in the
+// Authorization header (see middleware/auth-jwt.ts), never cookies, so the
+// browser never needs to send credentials cross-origin.
+app.use(cors({ origin: corsOrigin, credentials: false }));
 app.use(express.json({ limit: "1mb" }));
 app.use(requestIdMiddleware);
 app.use(metricsMiddleware);

--- a/docs/backend-deploy.md
+++ b/docs/backend-deploy.md
@@ -131,6 +131,12 @@ CORS_ORIGIN=https://splitnaira.vercel.app,https://app.splitnaira.com,https://spl
 
 If `CORS_ORIGIN` is missing or contains `*` in production the process will refuse to start with a descriptive error.
 
+### Credentials
+
+`Access-Control-Allow-Credentials` is never set (`credentials: false` is passed explicitly to the `cors` middleware in `src/index.ts`). This is intentional, not an oversight: the API authenticates with a bearer token in the `Authorization` header (see `src/middleware/auth-jwt.ts`), never cookies, so the browser has no session cookie to send cross-origin and credentialed CORS is unnecessary attack surface. Do not flip this to `true` without also switching auth to a cookie-based scheme.
+
+The origin allowlist logic lives in `src/config/cors.ts` (`resolveCorsOrigins`) and is exercised directly by `src/__tests__/cors.test.ts`, which covers: an allowed production origin, a disallowed origin, requests with no `Origin` header (non-browser clients), the local development default, and the wildcard-in-production rejection.
+
 ---
 
 ## Structured Logging


### PR DESCRIPTION
…v origins

Extract CORS origin resolution into config/cors.ts (shared by src/index.ts and the test suite) instead of duplicating the parsing/wildcard-guard logic in a test-only reimplementation, so tests exercise the real production codepath. Add coverage for a missing Origin header (non-browser clients), the local dev default, and explicitly assert Access-Control-Allow-Credentials is never set (auth is bearer-token based, not cookie based). Document the CORS_ORIGIN contract and credentials decision in .env.example and docs/backend-deploy.md. Also fixes a pre-existing test bug where the production-env CORS test was missing the now-required PAYMENTS_ADMIN_API_KEY stub.

## Summary
<!-- What does this PR do? Link the issue(s) it closes. -->

Closes #
Closes #854
Closes #855
Closes #853
Closes #824

## Changes
<!-- Bullet list of significant changes -->
-

## Testing
<!-- How was this tested? Unit tests, E2E, manual steps? -->
- [ ] Unit tests added / updated
- [ ] Integration / E2E tests pass
- [ ] Manually verified on local stack

## Deploy Impact
<!-- Complete this section for any PR that ships to production -->

### Risk level
- [ ] Low — docs/config only, no logic change
- [ ] Medium — logic change, backward-compatible
- [ ] High — breaking change, contract change, or schema migration

### Contract changes
- [ ] No contract changes
- [ ] Contract changes included — migration plan: <!-- describe -->

### Database migrations
- [ ] No migrations
- [ ] Migration included — rollback script: <!-- path -->

### Environment variables
- [ ] No new env vars
- [ ] New env vars added to `.env.example`

### Rollback plan
<!-- How do we revert if this breaks in production? -->

---
See [release readiness checklist](../docs/release-readiness-checklist.md) for
the full pre-deploy gate.
