### PR TITLE
docs(backend): document env var ownership, secrets, and rotation notes

### DIFF
--- a/docs/backend-env-vars.md
+++ b/docs/backend-env-vars.md
@@ -1,0 +1,60 @@
+﻿# Backend Environment Variables
+
+This document maps each backend environment variable to its owner area, the
+environments it applies to, and whether it is secret or public config. See
+`backend/.env.example` for the canonical list of variables and defaults.
+
+Related docs:
+- [`secrets.md`](./secrets.md) - full secret inventory, storage, and rotation procedures
+- [`environments.md`](./environments.md) - dev/staging/production configuration matrix
+
+| Variable | Owner Area | Required Environments | Secret? | Notes |
+|---|---|---|---|---|
+| PORT | Backend | dev, staging, prod | Public | Defaults to 3001 |
+| CORS_ORIGIN | Backend/Security | dev, staging, prod | Public | Must be explicit origins in production; wildcard rejected. See environment matrix in `environments.md` |
+| LOG_LEVEL | Backend | dev, staging, prod | Public | Controls log verbosity |
+| LOG_FORMAT | Backend | dev, staging, prod | Public | `json` in prod for log drains, `pretty` in dev |
+| DATABASE_URL | Backend/Infra | dev, staging, prod | **Secret** | See `secrets.md` for rotation procedure |
+| HORIZON_URL | Backend/Contracts | dev, staging, prod | Public | Stellar Horizon endpoint |
+| SOROBAN_RPC_URL | Backend/Contracts | dev, staging, prod | Public | Must match network per `environments.md` |
+| SOROBAN_NETWORK_PASSPHRASE | Backend/Contracts | dev, staging, prod | Public | Network identifier |
+| CONTRACT_ID | Backend/Contracts | dev, staging, prod | Public | Must match deployed contract per `environments.md` |
+| SIMULATOR_ACCOUNT | Backend/Contracts | dev, staging (rarely prod) | Public | Used for simulation only |
+| SENTRY_DSN | Backend/Monitoring | staging, prod (optional) | **Secret** | Leave blank to disable Sentry; see `secrets.md` |
+| SENTRY_ENVIRONMENT | Backend/Monitoring | staging, prod (optional) | Public | Tags errors by environment |
+| SENTRY_SCRUB_WALLET_ADDRESSES | Backend/Monitoring | staging, prod (optional) | Public | Privacy control for error reports |
+| PAYMENTS_ADMIN_API_KEY | Backend/Payments | prod (required), staging | **Secret** | Protects `/splits/admin` routes; see `secrets.md` for rotation and approval process |
+| PAYMENTS_ADMIN_WRITE_ENABLED | Backend/Payments | prod, staging | Public | Kill-switch to freeze admin payout routes without redeploy; changes require team awareness |
+| STRICT_RESPONSE_VALIDATION | Backend | dev, staging, prod (optional) | Public | Defaults `true` in prod |
+| READ_CACHE_TTL_MS | Backend/Performance | dev, staging, prod (optional) | Public | Cache tuning |
+| READ_CACHE_MAX_ENTRIES | Backend/Performance | dev, staging, prod (optional) | Public | Cache tuning |
+| DATABASE_POOL_MAX | Backend/Performance | dev, staging, prod (optional) | Public | DB connection pool size |
+
+## Secret vs Public Config
+
+Variables marked **Secret** above must never be committed to source control and
+must be stored in an approved secret store (GitHub Actions secrets, Render
+environment secrets, etc.). Full policy and rotation steps live in
+[`secrets.md`](./secrets.md).
+
+All other variables are **Public** - safe to expose in build logs or
+client-visible config, no special handling needed.
+
+## Rotation & Change Approval
+
+- **DATABASE_URL** and **SENTRY_DSN**: follow the general rotation procedure in
+  [`secrets.md`](./secrets.md).
+- **PAYMENTS_ADMIN_API_KEY**: requires sign-off before rotation, since it
+  protects admin payout and allowlist mutation routes. Coordinate with whoever
+  manages `/splits/admin`. See [`secrets.md`](./secrets.md) for the general
+  process.
+- **PAYMENTS_ADMIN_WRITE_ENABLED**: not a secret, but toggling it in production
+  is a functional change (freezes payout routes) - treat changes as requiring
+  team awareness, not just a config edit.
+- For which values are expected per environment (dev/staging/prod), see the
+  matrix in [`environments.md`](./environments.md).
+
+## Env Examples
+
+- Backend: [`backend/.env.example`](../backend/.env.example)
+- Frontend: [`frontend/.env.example`](../frontend/.env.example)


### PR DESCRIPTION
PR 1
Adds `docs/backend-env-vars.md`, documenting ownership, required environments, 
and secret/public classification for every backend environment variable 
defined in `backend/.env.example`.

Changes
- Table mapping each backend env var to owner area, required environments 
  (dev/staging/prod), and secret vs public status
- Rotation and change-approval notes for sensitive variables 
  (`DATABASE_URL`, `SENTRY_DSN`, `PAYMENTS_ADMIN_API_KEY`, `PAYMENTS_ADMIN_WRITE_ENABLED`)
- Cross-links to existing `docs/secrets.md` and `docs/environments.md` 
  instead of duplicating their content
- Links to `backend/.env.example` and `frontend/.env.example`

PR 2
Summary
Adds frontend tests covering rollback of optimistic transaction state when 
signing or submission fails, preventing stale "pending" UI.

Changes
- Test: wallet signing rejection clears optimistic pending state
- Test: RPC submission failure clears optimistic pending state
- Test: form data is preserved when retry is possible
- Test: distinct, user-facing failure messages are shown for signing 
  failure vs submission failure

PR 3
 Summary
Adds frontend tests verifying that error boundaries provide a working 
recovery path and reset correctly after route changes, preventing users 
from getting stuck on a fallback screen.

Changes
- Test: triggering a component error in a test route renders the fallback UI
- Test: retry/reset action clears the fallback once the underlying error is gone
- Test: navigating to a different route resets the error boundary state
- Test: fallback UI meets accessibility expectations (e.g. focus management, 
  ARIA roles/labels)

PR 4
Summary
Adds a smoke test verifying that upgrading the smart contract preserves 
compatibility with existing stored project data, catching storage or 
interface breaks before they reach production.

Changes
- Test fixture: state created using the previous contract shape/build
- Test: contract upgraded to the new build against that fixture
- Test: existing project reads and other safe (non-mutating) operations 
  still succeed post-upgrade
- Docs: process for updating the fixture when the contract shape changes 
  intentionally

Closes #955 
Closes #956 
Closes #954 
Closes #953 
