### PR TITLE
feat: backend logging redaction tests, contract address validation, onboarding docs, clipboard fallback tests

### DIFF
--- a/backend/src/__tests__/request-logging-redaction.test.ts
+++ b/backend/src/__tests__/request-logging-redaction.test.ts
@@ -1,0 +1,125 @@
+// #946 — Backend tests: request logging interceptor must never emit cookie
+// values or Authorization header contents in log output.
+//
+// Redacted fields:
+//   cookie        → omitted entirely from the logged object
+//   authorization → omitted entirely from the logged object
+// Preserved fields:
+//   method, path (url), correlationId, durationMs
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ExecutionContext, CallHandler } from "@nestjs/common";
+import { of } from "rxjs";
+import { RequestLoggingInterceptor } from "../observability/request-logging.interceptor.js";
+
+function makeContext(headers: Record<string, string> = {}, extras: Record<string, unknown> = {}): ExecutionContext {
+  const request = {
+    method: "GET",
+    url: "/api/projects",
+    correlationId: "test-corr-id",
+    headers,
+    ...extras,
+  };
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+function makeHandler(): CallHandler {
+  return { handle: () => of(null) };
+}
+
+describe("RequestLoggingInterceptor — cookie and auth redaction (#946)", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let interceptor: RequestLoggingInterceptor;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    interceptor = new RequestLoggingInterceptor();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  it("logs method and path for a plain request", async () => {
+    await new Promise<void>((resolve) => {
+      interceptor
+        .intercept(makeContext(), makeHandler())
+        .subscribe({ complete: resolve });
+    });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(logged.method).toBe("GET");
+    expect(logged.path).toBe("/api/projects");
+  });
+
+  it("never logs a cookie header value", async () => {
+    const ctx = makeContext({ cookie: "session=super-secret-token; other=value" });
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(ctx, makeHandler()).subscribe({ complete: resolve });
+    });
+
+    const raw = consoleSpy.mock.calls[0][0] as string;
+    expect(raw).not.toContain("super-secret-token");
+    expect(raw).not.toContain("session=");
+
+    const logged = JSON.parse(raw);
+    expect(logged.cookie).toBeUndefined();
+    expect(logged.headers?.cookie).toBeUndefined();
+  });
+
+  it("never logs an Authorization header value", async () => {
+    const ctx = makeContext({ authorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.secret" });
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(ctx, makeHandler()).subscribe({ complete: resolve });
+    });
+
+    const raw = consoleSpy.mock.calls[0][0] as string;
+    expect(raw).not.toContain("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9");
+    expect(raw).not.toContain("Bearer ");
+
+    const logged = JSON.parse(raw);
+    expect(logged.authorization).toBeUndefined();
+    expect(logged.headers?.authorization).toBeUndefined();
+  });
+
+  it("preserves correlationId in the log entry", async () => {
+    const ctx = makeContext({}, { correlationId: "abc-123" });
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(ctx, makeHandler()).subscribe({ complete: resolve });
+    });
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(logged.correlationId).toBe("abc-123");
+  });
+
+  it("includes a non-negative durationMs", async () => {
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(makeContext(), makeHandler()).subscribe({ complete: resolve });
+    });
+
+    const logged = JSON.parse(consoleSpy.mock.calls[0][0] as string);
+    expect(typeof logged.durationMs).toBe("number");
+    expect(logged.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not log both cookie and auth when both are present", async () => {
+    const ctx = makeContext({
+      cookie: "token=abc123",
+      authorization: "Bearer secret-jwt",
+    });
+
+    await new Promise<void>((resolve) => {
+      interceptor.intercept(ctx, makeHandler()).subscribe({ complete: resolve });
+    });
+
+    const raw = consoleSpy.mock.calls[0][0] as string;
+    expect(raw).not.toContain("abc123");
+    expect(raw).not.toContain("secret-jwt");
+  });
+});

--- a/contracts/address_validation_tests.rs
+++ b/contracts/address_validation_tests.rs
@@ -1,0 +1,344 @@
+#![cfg(test)]
+//! Collaborator address validation tests (issue #948).
+//!
+//! Covers `validate_collaborators` and `create_project` responses to invalid
+//! inputs: zero basis points, duplicate addresses, too few collaborators,
+//! invalid split totals, and the happy-path confirming that well-formed
+//! collaborator lists are accepted.
+
+use crate::{errors::SplitError, Collaborator, SplitNairaContract, SplitNairaContractClient};
+use soroban_sdk::{testutils::Address as _, vec, Address, Env, String, Symbol, Vec};
+
+fn setup() -> (Env, SplitNairaContractClient, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract(token_admin);
+    let contract_id = env.register_contract(None, SplitNairaContract);
+    let client = SplitNairaContractClient::new(&env, &contract_id);
+    (env, client, token)
+}
+
+fn new_project_id(env: &Env, name: &str) -> Symbol {
+    Symbol::new(env, name)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy path
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_project_with_valid_addresses_succeeds() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: alice,
+            alias: String::from_str(&env, "Alice"),
+            basis_points: 6000,
+        },
+        Collaborator {
+            address: bob,
+            alias: String::from_str(&env, "Bob"),
+            basis_points: 4000,
+        },
+    ];
+
+    client.create_project(
+        &owner,
+        &new_project_id(&env, "valid_split"),
+        &String::from_str(&env, "Valid Split Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(client.get_project_count(), 1);
+}
+
+#[test]
+fn create_project_with_three_collaborators_succeeds() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "Producer"),
+            basis_points: 5000,
+        },
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "Artist"),
+            basis_points: 3000,
+        },
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "Label"),
+            basis_points: 2000,
+        },
+    ];
+
+    client.create_project(
+        &owner,
+        &new_project_id(&env, "triple_split"),
+        &String::from_str(&env, "Triple Split"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(client.get_project_count(), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TooFewCollaborators
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_project_with_one_collaborator_returns_too_few() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "Solo"),
+            basis_points: 10000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "solo_project"),
+        &String::from_str(&env, "Solo Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::TooFewCollaborators)));
+}
+
+#[test]
+fn create_project_with_empty_collaborators_returns_too_few() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs: Vec<Collaborator> = Vec::new(&env);
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "empty_project"),
+        &String::from_str(&env, "Empty Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::TooFewCollaborators)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ZeroShare
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_project_with_zero_basis_points_returns_zero_share() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: alice,
+            alias: String::from_str(&env, "Alice"),
+            basis_points: 0, // invalid — zero share
+        },
+        Collaborator {
+            address: bob,
+            alias: String::from_str(&env, "Bob"),
+            basis_points: 10000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "zero_share"),
+        &String::from_str(&env, "Zero Share Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::ZeroShare)));
+}
+
+#[test]
+fn create_project_all_zero_basis_points_returns_zero_share() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "A"),
+            basis_points: 0,
+        },
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "B"),
+            basis_points: 0,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "all_zero"),
+        &String::from_str(&env, "All Zero Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::ZeroShare)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DuplicateCollaborator
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_project_with_duplicate_address_returns_duplicate_error() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+    let same_addr = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: same_addr.clone(),
+            alias: String::from_str(&env, "Alice"),
+            basis_points: 5000,
+        },
+        Collaborator {
+            address: same_addr.clone(), // same address again
+            alias: String::from_str(&env, "Also Alice"),
+            basis_points: 5000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "dup_collab"),
+        &String::from_str(&env, "Duplicate Collaborator Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::DuplicateCollaborator)));
+}
+
+#[test]
+fn create_project_duplicate_in_three_returns_duplicate_error() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+    let dup_addr = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "First"),
+            basis_points: 4000,
+        },
+        Collaborator {
+            address: dup_addr.clone(),
+            alias: String::from_str(&env, "Second"),
+            basis_points: 3000,
+        },
+        Collaborator {
+            address: dup_addr.clone(), // duplicate of Second
+            alias: String::from_str(&env, "Third"),
+            basis_points: 3000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "dup_mid"),
+        &String::from_str(&env, "Mid Duplicate Project"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::DuplicateCollaborator)));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InvalidSplit (basis points don't sum to 10 000)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn create_project_basis_points_under_ten_thousand_returns_invalid_split() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "A"),
+            basis_points: 4000, // total = 7000 ≠ 10000
+        },
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "B"),
+            basis_points: 3000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "under_split"),
+        &String::from_str(&env, "Under Split"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::InvalidSplit)));
+}
+
+#[test]
+fn create_project_basis_points_over_ten_thousand_returns_invalid_split() {
+    let (env, client, token) = setup();
+    let owner = Address::generate(&env);
+
+    let collabs = vec![
+        &env,
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "A"),
+            basis_points: 7000, // total = 13000 ≠ 10000
+        },
+        Collaborator {
+            address: Address::generate(&env),
+            alias: String::from_str(&env, "B"),
+            basis_points: 6000,
+        },
+    ];
+
+    let result = client.try_create_project(
+        &owner,
+        &new_project_id(&env, "over_split"),
+        &String::from_str(&env, "Over Split"),
+        &String::from_str(&env, "music"),
+        &token,
+        &collabs,
+    );
+    assert_eq!(result, Err(Ok(SplitError::InvalidSplit)));
+}

--- a/contracts/lib.rs
+++ b/contracts/lib.rs
@@ -40,6 +40,8 @@ mod hardening_tests;
 mod reliability_tests;
 #[cfg(test)]
 mod authorization_tests;
+#[cfg(test)]
+mod address_validation_tests;
 
 use errors::SplitError;
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,110 @@
+# First-Time Contributor Onboarding — SplitNaira
+
+Welcome! This checklist gets you from zero to a passing test run.
+
+---
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 20 LTS or later | `node --version` |
+| pnpm | 8+ | `npm i -g pnpm` |
+| Rust | stable | `rustup install stable` |
+| `soroban-cli` | 20.x | `cargo install --locked soroban-cli` |
+| Docker | any | Required for local Postgres |
+
+---
+
+## Setup checklist
+
+- [ ] **Clone and install**
+
+  ```bash
+  git clone https://github.com/Split-Naira/SplitNaira.git
+  cd SplitNaira
+  pnpm install
+  ```
+
+- [ ] **Copy environment files**
+
+  ```bash
+  cp backend/.env.example backend/.env
+  cp frontend/.env.example frontend/.env.local
+  ```
+
+  Edit both files — the only required change for local dev is setting a `DATABASE_URL` pointing at the Docker Postgres instance (started below).
+
+- [ ] **Start the database**
+
+  ```bash
+  docker compose up -d postgres
+  ```
+
+- [ ] **Run backend migrations**
+
+  ```bash
+  cd backend && pnpm run migrate
+  ```
+
+- [ ] **Build and test the Soroban contracts**
+
+  ```bash
+  cd contracts
+  cargo test --features testutils
+  ```
+
+  All tests should pass. If you see linker errors, run `rustup target add wasm32-unknown-unknown`.
+
+- [ ] **Start backend dev server**
+
+  ```bash
+  cd backend && pnpm run dev
+  ```
+
+- [ ] **Start frontend dev server** (new terminal)
+
+  ```bash
+  cd frontend && pnpm run dev
+  ```
+
+  Open [http://localhost:3000](http://localhost:3000).
+
+- [ ] **Run the full test suite**
+
+  ```bash
+  pnpm -r run test
+  ```
+
+---
+
+## Good first issues
+
+Look for issues labelled [`good first issue`](https://github.com/Split-Naira/SplitNaira/issues?q=is%3Aopen+label%3A%22good+first+issue%22) on GitHub.
+
+---
+
+## Troubleshooting
+
+**`cargo test` fails with `no such table` / Diesel error**
+Run `cd backend && pnpm run migrate` to apply pending migrations before testing.
+
+**Port 3000 already in use**
+Set `PORT=3001` in `frontend/.env.local` or stop the process occupying 3000.
+
+**`soroban-cli` not found after install**
+Make sure `~/.cargo/bin` is on your `$PATH` (`source ~/.cargo/env`).
+
+**`pnpm install` fails on native modules**
+Ensure you have the Xcode Command Line Tools (macOS: `xcode-select --install`) or `build-essential` (Linux) installed.
+
+---
+
+## Submitting a PR
+
+1. Fork the repo and create a branch off `main`: `git checkout -b feat/my-feature`.
+2. Make your changes with tests.
+3. Push and open a PR against `Split-Naira/SplitNaira:main`.
+4. Add `Closes #<issue-number>` in the PR description so the issue closes automatically.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for code style and review guidelines.

--- a/frontend/src/components/__tests__/CopyAddressButton.test.tsx
+++ b/frontend/src/components/__tests__/CopyAddressButton.test.tsx
@@ -1,0 +1,149 @@
+/* @vitest-environment jsdom */
+// #949 — Clipboard fallback behavior tests for CopyAddressButton.
+//
+// Covers: clipboard API unavailable (navigator.clipboard is undefined),
+// writeText rejection (permission denied), and the happy-path to confirm
+// normal behavior still works.
+
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { CopyAddressButton } from "../CopyAddressButton";
+
+const MOCK_ADDRESS = "GBMJFZXMLRJF5TGSEPQ4GJ2UT7PJYCRQEXW7JZ7ZDQEXCZWJ5YN4HCC";
+
+describe("CopyAddressButton — clipboard fallback behavior (#949)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when navigator.clipboard is available", () => {
+    let writeTextMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      writeTextMock = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("renders copy button with accessible label", () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("Copy address to clipboard");
+    });
+
+    it("calls clipboard.writeText with the full address", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      expect(writeTextMock).toHaveBeenCalledOnce();
+      expect(writeTextMock).toHaveBeenCalledWith(MOCK_ADDRESS);
+    });
+
+    it("shows copied state after a successful write", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("Address copied");
+      expect(button.getAttribute("title")).toBe("Copied!");
+    });
+
+    it("reverts to initial state after 2 seconds", async () => {
+      vi.useFakeTimers();
+
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      expect(screen.getByRole("button").getAttribute("aria-label")).toBe("Address copied");
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(screen.getByRole("button").getAttribute("aria-label")).toBe("Copy address to clipboard");
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("clipboard permission denied (writeText rejects)", () => {
+    let writeTextMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      writeTextMock = vi.fn().mockRejectedValue(
+        new DOMException("Permission denied", "NotAllowedError")
+      );
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("does not throw when clipboard permission is denied", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await expect(
+        act(async () => {
+          fireEvent.click(screen.getByRole("button"));
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it("stays in initial state when clipboard write is rejected", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("Copy address to clipboard");
+      expect(button.getAttribute("title")).toBe("Copy address");
+    });
+  });
+
+  describe("clipboard API unavailable (navigator.clipboard is undefined)", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it("does not throw when navigator.clipboard is undefined", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await expect(
+        act(async () => {
+          fireEvent.click(screen.getByRole("button"));
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it("stays in initial state when clipboard is unavailable", async () => {
+      render(<CopyAddressButton address={MOCK_ADDRESS} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("Copy address to clipboard");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **#946** — Added `backend/src/__tests__/request-logging-redaction.test.ts`: 6 vitest cases confirming `RequestLoggingInterceptor` never emits `cookie` or `Authorization` header values in log output, while preserving `method`, `path`, `correlationId`, and `durationMs`.

- **#948** — Added `contracts/address_validation_tests.rs`: 9 Soroban contract tests covering all `validate_collaborators` rejection paths (`TooFewCollaborators`, `ZeroShare`, `DuplicateCollaborator`, `InvalidSplit`) plus happy-path success with valid collaborator addresses. Module registered in `contracts/lib.rs`.

- **#947** — Added `docs/ONBOARDING.md`: first-time contributor onboarding checklist with prerequisites table, step-by-step setup (clone → env → Docker Postgres → migrations → contract tests → dev servers), good-first-issues link, and troubleshooting section.

- **#949** — Added `frontend/src/components/__tests__/CopyAddressButton.test.tsx`: clipboard fallback tests covering `navigator.clipboard` undefined, `writeText` rejection (`NotAllowedError`), successful copy state, and 2-second revert timer.

## Test plan

- [ ] `cd backend && pnpm test` — `request-logging-redaction.test.ts` all pass
- [ ] `cd contracts && cargo test --features testutils` — `address_validation_tests` all pass
- [ ] `cd frontend && pnpm test` — `CopyAddressButton.test.tsx` all pass

Closes #946, Closes #947, Closes #948, Closes #949