### PR TITLE
Add client-side search/filter to ProjectsList with tests (#939)

### DIFF
--- a/frontend/src/components/projects/ProjectsList.test.tsx
+++ b/frontend/src/components/projects/ProjectsList.test.tsx
@@ -1,0 +1,208 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ProjectsList } from "./ProjectsList";
+import type { SplitProject } from "@/lib/stellar";
+import type { WalletState } from "@/lib/wallet";
+
+const wallet: WalletState = { connected: false, address: null, network: "testnet" };
+
+const buildProject = (overrides: Partial<SplitProject> = {}): SplitProject => ({
+  projectId: "P1",
+  title: "Default Project",
+  projectType: "App",
+  token: "",
+  owner: "GOWNER",
+  collaborators: [{ address: "GADDR1", alias: "Alice", basisPoints: 10_000 }],
+  locked: false,
+  totalDistributed: "0",
+  distributionRound: 0,
+  balance: "0",
+  ...overrides,
+});
+
+function baseProps(overrides: Partial<ComponentProps<typeof ProjectsList>> = {}) {
+  return {
+    wallet,
+    selectedProjectId: null,
+    setSelectedProjectId: vi.fn(),
+    projectsList: [] as SplitProject[],
+    onFetchProjectsList: vi.fn().mockResolvedValue(undefined),
+    isLoadingProjectsList: false,
+    projectsListError: null,
+    isProjectsListStale: false,
+    hasMoreProjects: false,
+    fetchedProject: null,
+    setFetchedProject: vi.fn(),
+    fetchHistory: vi.fn().mockResolvedValue(undefined),
+    isLoadingHistory: false,
+    history: [],
+    historyError: null,
+    isHistoryStale: false,
+    historyCursor: null,
+    setShowDistributeModal: vi.fn(),
+    adminStatus: null,
+    receipt: null,
+    sorobanSplitFlowBusy: false,
+    getExplorerUrl: vi.fn().mockReturnValue("https://example.com"),
+    getExplorerLabel: vi.fn().mockReturnValue("Explorer"),
+    ...overrides,
+  };
+}
+
+const searchInput = () => screen.getByRole("textbox", { name: /search projects/i });
+const clearButton = () => screen.getByRole("button", { name: /clear search/i });
+
+describe("ProjectsList search and filtering", () => {
+  it("renders all projects when no search query is entered (baseline)", () => {
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.getByText("Beta Launch")).toBeInTheDocument();
+  });
+
+  it("narrows results when searching by project title", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    await user.type(searchInput(), "Alpha");
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.queryByText("Beta Launch")).not.toBeInTheDocument();
+  });
+
+  it("narrows results when searching by collaborator alias", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({
+        projectId: "P1",
+        title: "Alpha Rocket",
+        collaborators: [{ address: "GADDR1", alias: "Zara", basisPoints: 10_000 }],
+      }),
+      buildProject({
+        projectId: "P2",
+        title: "Beta Launch",
+        collaborators: [{ address: "GADDR2", alias: "Marcus", basisPoints: 10_000 }],
+      }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    await user.type(searchInput(), "zara");
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.queryByText("Beta Launch")).not.toBeInTheDocument();
+  });
+
+  it("narrows results when searching by collaborator address", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({
+        projectId: "P1",
+        title: "Alpha Rocket",
+        collaborators: [{ address: "GSPECIALADDRESS", alias: "Zara", basisPoints: 10_000 }],
+      }),
+      buildProject({
+        projectId: "P2",
+        title: "Beta Launch",
+        collaborators: [{ address: "GOTHERADDRESS", alias: "Marcus", basisPoints: 10_000 }],
+      }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    await user.type(searchInput(), "specialaddress");
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.queryByText("Beta Launch")).not.toBeInTheDocument();
+  });
+
+  it("restores full results when the Clear button is clicked", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    await user.type(searchInput(), "Alpha");
+    expect(screen.queryByText("Beta Launch")).not.toBeInTheDocument();
+
+    await user.click(clearButton());
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.getByText("Beta Launch")).toBeInTheDocument();
+    expect(searchInput()).toHaveValue("");
+  });
+
+  it("restores full results when the search text is manually cleared by deleting", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    const input = searchInput();
+    await user.type(input, "Alpha");
+    expect(screen.queryByText("Beta Launch")).not.toBeInTheDocument();
+
+    await user.clear(input);
+
+    expect(screen.getByText("Alpha Rocket")).toBeInTheDocument();
+    expect(screen.getByText("Beta Launch")).toBeInTheDocument();
+  });
+
+  it("shows a distinct no-matches empty state when a search yields zero of N loaded projects", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    await user.type(searchInput(), "nonexistent-project-xyz");
+
+    expect(screen.getByText(/no projects match your search/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no projects found\. click refresh projects to load\./i)).not.toBeInTheDocument();
+    // A way to clear the search from this empty state too (in addition to the
+    // always-present header Clear button, the empty state itself renders one).
+    expect(screen.getAllByRole("button", { name: /clear search/i }).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("shows the original empty state when zero projects are loaded at all (no search active)", () => {
+    render(<ProjectsList {...baseProps({ projectsList: [] })} />);
+
+    expect(screen.getByText(/no projects found\. click refresh projects to load\./i)).toBeInTheDocument();
+    expect(screen.queryByText(/no projects match your search/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps keyboard focus on the search input across multiple sequential keystrokes", async () => {
+    const user = userEvent.setup();
+    const projectsList = [
+      buildProject({ projectId: "P1", title: "Alpha Rocket" }),
+      buildProject({ projectId: "P2", title: "Beta Launch" }),
+    ];
+    render(<ProjectsList {...baseProps({ projectsList })} />);
+
+    const input = searchInput();
+    await user.click(input);
+    expect(input).toHaveFocus();
+
+    for (const char of "Alpha") {
+      await user.keyboard(char);
+      expect(input).toHaveFocus();
+      expect(document.activeElement).toBe(input);
+    }
+  });
+});

--- a/frontend/src/components/projects/ProjectsList.tsx
+++ b/frontend/src/components/projects/ProjectsList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { clsx } from "clsx";
 import { sanitizeText } from "@/lib/security";
 import type { SplitProject } from "@/lib/stellar";
@@ -60,6 +61,25 @@ export function ProjectsList({
   getExplorerUrl,
   getExplorerLabel,
 }: ProjectsListProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+
+  const filteredProjectsList = useMemo(() => {
+    if (!trimmedQuery) return projectsList;
+    return projectsList.filter((p) => {
+      if (p.title.toLowerCase().includes(trimmedQuery)) return true;
+      return p.collaborators.some(
+        (collab) =>
+          collab.alias.toLowerCase().includes(trimmedQuery) ||
+          collab.address.toLowerCase().includes(trimmedQuery),
+      );
+    });
+  }, [projectsList, trimmedQuery]);
+
+  const isSearchActive = trimmedQuery.length > 0;
+  const clearSearch = () => setSearchQuery("");
+
   return (
     <div className="space-y-10">
       {selectedProjectId === null ? (
@@ -102,11 +122,38 @@ export function ProjectsList({
               </div>
             )}
           </div>
+
+          <div className="glass-card rounded-[2.5rem] p-6 md:p-8 flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
+            <div className="flex-1">
+              <label htmlFor="project-search-input" className="sr-only">
+                Search projects by name or collaborator
+              </label>
+              <input
+                id="project-search-input"
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search by project name or collaborator…"
+                aria-label="Search projects by name or collaborator"
+                className="w-full rounded-2xl bg-white/5 border border-white/10 px-5 py-3 text-sm text-ink placeholder:text-muted/50 focus:outline-none focus:border-greenBright/50 transition-colors"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={clearSearch}
+              disabled={!isSearchActive}
+              aria-label="Clear search"
+              className="premium-button rounded-2xl bg-white/5 border border-white/10 px-6 py-3 text-xs font-bold uppercase tracking-widest text-muted hover:text-ink hover:bg-white/10 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              Clear
+            </button>
+          </div>
+
           {isLoadingProjectsList && projectsList.length === 0 ? (
             <DashboardGridSkeleton count={4} />
-          ) : projectsList.length > 0 ? (
+          ) : filteredProjectsList.length > 0 ? (
             <div className="grid gap-6 md:grid-cols-2 animate-in fade-in">
-              {projectsList.map((p) => (
+              {filteredProjectsList.map((p) => (
                 <ProjectCard
                   key={p.projectId}
                   project={p}
@@ -117,6 +164,19 @@ export function ProjectsList({
                   }}
                 />
               ))}
+            </div>
+          ) : projectsList.length > 0 && isSearchActive ? (
+            <div className="glass-card rounded-[2.5rem] p-12 text-center space-y-4">
+              <p className="text-muted text-sm font-medium">
+                No projects match your search. Try a different name or clear your search.
+              </p>
+              <button
+                type="button"
+                onClick={clearSearch}
+                className="premium-button inline-flex items-center gap-2 rounded-2xl bg-white/5 border border-white/10 px-6 py-3 text-xs font-bold uppercase tracking-widest text-muted hover:text-ink hover:bg-white/10 transition-all"
+              >
+                Clear Search
+              </button>
             </div>
           ) : (
             <div className="glass-card rounded-[2.5rem] p-12 text-center">


### PR DESCRIPTION
## Summary
- `ProjectsList.tsx` had no search/filter UI at all prior to this change — since the acceptance criteria require testing behaviors that didn't exist yet, this PR implements a small, scoped client-side search/filter feature alongside its tests
- Case-insensitive substring search against project title and collaborator alias/address; local `useState` + `useMemo`, no new props threaded from the parent
- Distinct empty states: "no projects loaded" (unchanged) vs. "no projects match your search" (new), each with its own clear-search affordance
- Search input renders unconditionally (never conditionally unmounted) so keyboard focus survives re-renders across keystrokes
- Filtering applies only to the already-loaded page — pagination/`onFetchProjectsList` untouched by design (documented as a deliberate scope decision)

## Acceptance criteria
- [x] Search by project name and collaborator (alias + address)
- [x] Clearing filters (Clear button and manually emptying the input) restores results
- [x] Useful, distinct empty state for no matches
- [x] Keyboard focus stays on the input across sequential keystrokes (tested explicitly)

## Test plan
- [x] `npx vitest run ProjectsList` — 9/9 passing
- [x] Full `npm run test` — 166 passed / 20 failed; confirmed via `git stash` the 20 failures are pre-existing and unrelated (unaffected by this change)
- [x] `npx eslint` scoped to the two touched files — zero errors (full-suite lint has pre-existing, unrelated failures)

closes #939 