### PR TITLE
docs: add release note template and link from runbook (#938)

### DIFF
--- a/docs/DRAFT_RELEASE_NOTES_EXAMPLE.md
+++ b/docs/DRAFT_RELEASE_NOTES_EXAMPLE.md
@@ -1,0 +1,44 @@
+# Draft Release Notes — Worked Example
+
+<!-- Produced by filling in docs/RELEASE_NOTE_TEMPLATE.md using this repo's own recent
+     merge history (see `git log --oneline -20 main`), as validation that the template
+     is usable in practice. This is illustrative, not a real published release. -->
+
+## Release: v0.2.0 — 2026-07-26
+
+## Features
+- Added API idempotency key support for create-split requests, so retried POSTs
+  no longer create duplicate splits (#887, #888, #889, #890)
+
+## Fixes
+- Fixed the 404 page rendering broken internal links (#970 area)
+- Added missing test coverage for backend rate-limit headers and 429 responses,
+  closing a gap where the limiter's behavior was unverified
+
+## Security
+- Added strict CORS test coverage for allowed/disallowed/missing/malformed
+  `Origin` headers in production mode, confirming the allow-list rejects
+  everything not explicitly permitted (#968)
+
+## Migrations
+- [x] No migrations required
+- No DB schema or contract storage changes in this batch — see
+  `docs/backend-deploy.md#database-migrations` and
+  `docs/contract-release-and-upgrade-runbook.md` for when this section applies.
+
+## Known Issues
+- CORS and rate-limit coverage in this release is test-only confirmation of
+  existing behavior, not a behavior change — operators relying on the previous
+  (undocumented) limiter thresholds should confirm no client depends on
+  undocumented retry timing before upgrading.
+
+## Docs & Screenshots Checklist
+- [x] Documentation updated (env var ownership doc merged same window, PR #971)
+- [ ] Screenshots attached for UI-visible changes — N/A, no UI changes in this batch
+- [x] Migration steps verified against a staging/test DB — N/A, no migrations
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`
+
+---
+Source commits (`git log --oneline -20 main`): `096ae66` (idempotency key support),
+`8935360` (CORS strict-prod tests), `df49f54` (404 page fix), `e7eafb7`
+(rate-limit header tests).

--- a/docs/RELEASE_NOTE_TEMPLATE.md
+++ b/docs/RELEASE_NOTE_TEMPLATE.md
@@ -1,0 +1,47 @@
+# Release Note Template
+<!-- Copy this into the PR description or a draft GitHub Release. Keep entries short —
+     this is a fill-in-the-blank, not an essay. "Features"/"Fixes" map to CHANGELOG.md's
+     "Added"/"Fixed" sections (Keep a Changelog); reuse the same wording in both places. -->
+
+## Release: vX.Y.Z — YYYY-MM-DD
+
+## Features
+<!-- e.g. Added API idempotency key support for create-split requests (#888) -->
+-
+
+## Fixes
+<!-- e.g. Fixed 404 page rendering broken internal links (#970) -->
+-
+
+## Security
+<!-- e.g. Tightened CORS to an explicit allow-list in production (#968) -->
+-
+
+## Migrations
+<!-- Link the actual mechanism, don't re-explain it:
+     - DB schema: docs/backend-deploy.md#database-migrations (`npm run migration:run`)
+     - Contract/storage: docs/contract-release-and-upgrade-runbook.md + the ADR at
+       docs/adr/0001-contract-upgrade-decision-record.md -->
+- [ ] No migrations required
+- [ ] Migration included — steps / rollback link:
+
+## Known Issues
+<!-- Be specific and honest: what breaks, who is affected, any workaround.
+     Weak: "some edge cases may fail."
+     Useful: "Bulk export times out for splits with >500 collaborators;
+              workaround: paginate via the API." -->
+-
+
+## Docs & Screenshots Checklist
+- [ ] Documentation updated (link: )
+- [ ] Screenshots attached for UI-visible changes
+- [ ] Migration steps verified against a staging/test DB
+- [ ] `CHANGELOG.md` entry added under `[Unreleased]`
+
+---
+See [docs/RELEASE_RUNBOOK.md](./RELEASE_RUNBOOK.md) for the full pre-release checklist
+and [docs/release-readiness-checklist.md](./release-readiness-checklist.md) for the
+contract/infra sign-off gate.
+
+A worked example filled in from this repo's own history is at
+[docs/DRAFT_RELEASE_NOTES_EXAMPLE.md](./DRAFT_RELEASE_NOTES_EXAMPLE.md).

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -6,3 +6,5 @@ Backend indexers and off-chain listeners rely on exact event topic structure and
 1. Run contract event tests from the `contracts/` directory:
    ```bash
    cargo test --manifest-path contracts/Cargo.toml --lib events
+   ```
+2. Draft your release notes using the [Release Note Template](./RELEASE_NOTE_TEMPLATE.md).


### PR DESCRIPTION
## Summary
- New `docs/RELEASE_NOTE_TEMPLATE.md`: concise, fill-in-the-blanks template (Features/Fixes/Security/Migrations/Known Issues, docs+screenshots checklist), styled after `.github/PULL_REQUEST_TEMPLATE.md`'s inline-HTML-comment guidance convention
- Verified `.github/workflows/release.yml`: it extracts the `## [<tag>]` section straight out of `CHANGELOG.md` as the GitHub Release body — there's no separate release-notes mechanism. The template's Features/Fixes/Security wording is aligned with `CHANGELOG.md`'s Keep-a-Changelog categories so a filled-in template pastes directly into a new changelog entry
- New `docs/DRAFT_RELEASE_NOTES_EXAMPLE.md`: a worked example (v0.2.0) filled in from this repo's own recent real commits (idempotency-key support, strict-CORS test coverage, a 404 page fix, rate-limit header/429 test coverage)
- Linked from `docs/RELEASE_RUNBOOK.md`'s existing Pre-release Checklist as a new step 2 (also fixed a pre-existing unclosed code fence in that file, found while editing the same section)

## Acceptance criteria
- [x] Template with sections for features, fixes, security, migrations, known issues
- [x] Checklist for docs and screenshots
- [x] Linked from release runbook
- [x] Kept concise (fits one screen, inline comment guidance instead of prose)

## Validation
- [x] Used the template for one draft release note (`docs/DRAFT_RELEASE_NOTES_EXAMPLE.md`), grounded in real recent commit history


closes #938