### PR TITLE
Add maintenance-mode banner and write-action gating (#934)

### DIFF
--- a/frontend/src/components/MaintenanceBanner.test.tsx
+++ b/frontend/src/components/MaintenanceBanner.test.tsx
@@ -1,0 +1,69 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MaintenanceBanner } from "./MaintenanceBanner";
+
+describe("MaintenanceBanner", () => {
+  it("renders nothing when status is 'ok'", () => {
+    const { container } = render(<MaintenanceBanner status="ok" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders an alert with default copy for 'degraded' status", () => {
+    render(<MaintenanceBanner status="degraded" />);
+
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+    expect(banner).toHaveTextContent(
+      "Some services are degraded. Read-only access is unaffected.",
+    );
+  });
+
+  it("renders an alert with default copy for 'maintenance' status", () => {
+    render(<MaintenanceBanner status="maintenance" />);
+
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(
+      "System is in maintenance mode. Write actions are temporarily disabled.",
+    );
+  });
+
+  it("prefers a backend-provided message over the default copy", () => {
+    render(
+      <MaintenanceBanner
+        status="maintenance"
+        message="Database migration in progress, ETA 15 minutes."
+      />,
+    );
+
+    expect(
+      screen.getByText("Database migration in progress, ETA 15 minutes."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(
+        "System is in maintenance mode. Write actions are temporarily disabled.",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to default copy when message is an empty string", () => {
+    render(<MaintenanceBanner status="degraded" message="   " />);
+
+    expect(
+      screen.getByText("Some services are degraded. Read-only access is unaffected."),
+    ).toBeTruthy();
+  });
+
+  it("has no dismiss control, unlike the dismissable error banner", () => {
+    render(<MaintenanceBanner status="maintenance" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("does not render for 'ok' even when a stray message is passed", () => {
+    const { container } = render(
+      <MaintenanceBanner status="ok" message="should not show" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/MaintenanceBanner.tsx
+++ b/frontend/src/components/MaintenanceBanner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * Concise, persistent banner surfacing backend maintenance/degraded status
+ * (#934). Styled consistently with NetworkStatusBanner's conventions
+ * (role="alert", aria-live, lucide icon, single-line message) but — unlike
+ * the dismissable NetworkErrorBanner — this has no dismiss control, since it
+ * should stay visible for the duration of the condition it reports.
+ */
+
+import { AlertTriangle, Wrench } from "lucide-react";
+
+import type { SystemStatus } from "@/lib/api-client";
+
+export interface MaintenanceBannerProps {
+  status: SystemStatus;
+  message?: string;
+  className?: string;
+}
+
+const DEFAULT_MESSAGES: Record<Exclude<SystemStatus, "ok">, string> = {
+  degraded: "Some services are degraded. Read-only access is unaffected.",
+  maintenance:
+    "System is in maintenance mode. Write actions are temporarily disabled.",
+};
+
+/**
+ * Renders nothing when `status` is "ok".
+ */
+export function MaintenanceBanner({
+  status,
+  message,
+  className,
+}: Readonly<MaintenanceBannerProps>) {
+  if (status === "ok") return null;
+
+  const isMaintenance = status === "maintenance";
+  const Icon = isMaintenance ? Wrench : AlertTriangle;
+  const text = message && message.trim() ? message : DEFAULT_MESSAGES[status];
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      data-testid="maintenance-banner"
+      className={`flex items-center gap-3 rounded-xl border p-4 text-sm ${
+        isMaintenance
+          ? "border-red-200 bg-red-50 text-red-700"
+          : "border-amber-200 bg-amber-50 text-amber-700"
+      } ${className ?? ""}`}
+    >
+      <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+      <p className="font-medium">{text}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/split-app-legacy.tsx
+++ b/frontend/src/components/split-app-legacy.tsx
@@ -112,8 +112,15 @@ const SEEDED_PROJECT_IDS = [
 
 export function SplitApp({
   onLoadingFlagsChange,
+  isWriteDisabled = false,
 }: {
   onLoadingFlagsChange?: (flags: LoadingBarFlags) => void;
+  /**
+   * True when the backend is reporting maintenance mode (#934). Gates the
+   * "Execute Payout" distribution action as a demonstrative write-action
+   * lock — read-only flows (viewing projects, history, etc.) stay open.
+   */
+  isWriteDisabled?: boolean;
 } = {}) {
   const { wallet, connect, refresh } = useWallet();
 
@@ -1272,7 +1279,7 @@ export function SplitApp({
             <div className="mt-10 flex flex-col gap-4">
               <button
                 onClick={onDistribute}
-                disabled={sorobanSplitFlowBusy}
+                disabled={sorobanSplitFlowBusy || isWriteDisabled}
                 className="premium-button w-full rounded-2xl bg-greenBright py-5 text-xs font-black uppercase tracking-[0.3em] text-[#0a0a09]"
               >
                 {isSubmitting
@@ -1281,6 +1288,11 @@ export function SplitApp({
                     : "Signing & submitting…"
                   : "Execute Payout"}
               </button>
+              {isWriteDisabled && (
+                <p className="text-center text-[10px] font-bold uppercase tracking-widest text-red-400">
+                  Unavailable during maintenance
+                </p>
+              )}
               <button
                 onClick={() => setShowDistributeModal(false)}
                 disabled={sorobanSplitFlowBusy}

--- a/frontend/src/components/split-app.test.tsx
+++ b/frontend/src/components/split-app.test.tsx
@@ -24,7 +24,23 @@ const mocks = vi.hoisted(() => ({
   mockBuildAllowTokenXdr: vi.fn(),
   mockBuildDisallowTokenXdr: vi.fn(),
   mockSendTransaction: vi.fn(),
-  mockPollTransaction: vi.fn()
+  mockPollTransaction: vi.fn(),
+  mockUseMaintenanceStatus: vi.fn()
+}));
+
+// Default: no maintenance-mode gating for the pre-existing test suites below.
+// Individual tests in the "#934 maintenance-mode write gating" describe
+// block override this per-case.
+beforeEach(() => {
+  mocks.mockUseMaintenanceStatus.mockReturnValue({
+    status: "ok",
+    isWriteDisabled: false,
+    message: undefined
+  });
+});
+
+vi.mock("@/hooks/useMaintenanceStatus", () => ({
+  useMaintenanceStatus: mocks.mockUseMaintenanceStatus
 }));
 
 vi.mock("@/lib/wallet", () => {
@@ -607,6 +623,137 @@ describe("SplitApp distribute flow", () => {
     await loadProject();
     expect(screen.getByRole("button", { name: "Trigger Distribution" })).toHaveProperty("disabled", true);
     expect(screen.getByText("No funds available to distribute")).toBeTruthy();
+  });
+});
+
+// ============================================================
+//  ISSUE #934 — maintenance-mode write-action gating
+//
+//  Demonstrative write-action gate: the "Execute Payout" button (the actual
+//  distribution/write action, inside the distribute confirmation modal in
+//  split-app-legacy.tsx) is disabled whenever useMaintenanceStatus() reports
+//  isWriteDisabled — while the read-only flow of opening the confirmation
+//  modal itself stays available.
+// ============================================================
+
+describe("SplitApp maintenance-mode write gating (#934)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockUseWallet.mockReturnValue({
+      wallet: { connected: true, address: "GOWNER123", network: "testnet" },
+      connect: vi.fn(),
+      refresh: vi.fn()
+    });
+    mocks.mockGetWalletState.mockResolvedValue({
+      connected: true,
+      address: "GOWNER123",
+      network: "testnet"
+    });
+    mocks.mockGetAllSplits.mockResolvedValue([]);
+    mocks.mockGetClaimable.mockResolvedValue({ claimed: "0", distributionRound: 0 });
+    mocks.mockGetProjectHistory.mockResolvedValue({ items: [], nextCursor: null });
+    mocks.mockGetTokenAllowlist.mockResolvedValue(baseAllowlist);
+    mocks.mockGetSplit.mockResolvedValue({ ...baseProject, balance: "5000" });
+    mocks.mockSignWithWallet.mockResolvedValue("SIGNED_XDR");
+    mocks.mockBuildDistributeXdr.mockResolvedValue({
+      xdr: "DISTRIBUTE_XDR",
+      metadata: { networkPassphrase: "TESTNET", contractId: "CID" }
+    });
+    mocks.mockSendTransaction.mockResolvedValue({ status: "PENDING", hash: "DIST_TX_HASH" });
+    mocks.mockPollTransaction.mockResolvedValue({ status: "SUCCESS" });
+  });
+
+  it("keeps Execute Payout enabled and callable when status is ok", async () => {
+    mocks.mockUseMaintenanceStatus.mockReturnValue({
+      status: "ok",
+      isWriteDisabled: false,
+      message: undefined
+    });
+
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+
+    expect(screen.getByRole("button", { name: "Execute Payout" })).toHaveProperty("disabled", false);
+    expect(screen.queryByText("Unavailable during maintenance")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Execute Payout" }));
+    await waitFor(() => {
+      expect(mocks.mockBuildDistributeXdr).toHaveBeenCalledWith("project_1", "GOWNER123");
+    });
+  });
+
+  it("disables Execute Payout and shows an inline note when status is maintenance", async () => {
+    mocks.mockUseMaintenanceStatus.mockReturnValue({
+      status: "maintenance",
+      isWriteDisabled: true,
+      message: "System is in maintenance mode."
+    });
+
+    const user = await loadProject();
+    // Read-only flow — opening the confirmation modal — still works.
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+    expect(screen.getByRole("heading", { name: "Final Confirmation" })).toBeTruthy();
+
+    const payoutButton = screen.getByRole("button", { name: "Execute Payout" });
+    expect(payoutButton).toHaveProperty("disabled", true);
+    expect(screen.getByText("Unavailable during maintenance")).toBeTruthy();
+
+    await user.click(payoutButton);
+    expect(mocks.mockBuildDistributeXdr).not.toHaveBeenCalled();
+  });
+
+  it("does not disable Execute Payout for a merely 'degraded' status", async () => {
+    mocks.mockUseMaintenanceStatus.mockReturnValue({
+      status: "degraded",
+      isWriteDisabled: false,
+      message: "Some services are degraded."
+    });
+
+    const user = await loadProject();
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+
+    expect(screen.getByRole("button", { name: "Execute Payout" })).toHaveProperty("disabled", false);
+    expect(screen.queryByText("Unavailable during maintenance")).toBeNull();
+  });
+
+  it("re-enables Execute Payout after leaving maintenance mode", async () => {
+    mocks.mockUseMaintenanceStatus.mockReturnValue({
+      status: "maintenance",
+      isWriteDisabled: true,
+      message: undefined
+    });
+
+    const user = userEvent.setup();
+    const view = renderSplitApp();
+
+    await user.click(screen.getByRole("button", { name: "Manage & Distribute" }));
+    await user.type(screen.getByPlaceholderText(/Enter Project ID/i), "project_1");
+    await user.click(screen.getByRole("button", { name: "Fetch Stats" }));
+    await screen.findByText("Project One");
+
+    await user.click(screen.getByRole("button", { name: "Trigger Distribution" }));
+    expect(screen.getByRole("button", { name: "Execute Payout" })).toHaveProperty("disabled", true);
+    expect(screen.getByText("Unavailable during maintenance")).toBeTruthy();
+
+    // Maintenance clears — simulate the hook's next poll tick reporting "ok".
+    // Force a re-render (as the next poll tick's setState would) so the
+    // SPA-root wrapper re-evaluates useMaintenanceStatus() and threads the
+    // fresh isWriteDisabled value down as a prop.
+    mocks.mockUseMaintenanceStatus.mockReturnValue({
+      status: "ok",
+      isWriteDisabled: false,
+      message: undefined
+    });
+    view.rerender(
+      <ToastProvider>
+        <WalletProvider>
+          <SplitApp />
+        </WalletProvider>
+      </ToastProvider>
+    );
+
+    expect(screen.getByRole("button", { name: "Execute Payout" })).toHaveProperty("disabled", false);
+    expect(screen.queryByText("Unavailable during maintenance")).toBeNull();
   });
 });
 

--- a/frontend/src/components/split-app.tsx
+++ b/frontend/src/components/split-app.tsx
@@ -7,6 +7,8 @@ import { useTranslations } from "next-intl";
 import { SplitApp as SplitAppLegacy } from "./split-app-legacy";
 import { useFocusTrap } from "./useFocusTrap";
 import useLockBodyScroll from "./useLockBodyScroll";
+import { useMaintenanceStatus } from "@/hooks/useMaintenanceStatus";
+import { MaintenanceBanner } from "./MaintenanceBanner";
 
 const MODAL_SELECTORS = [
   "[role='dialog'][aria-modal='true']",
@@ -28,6 +30,12 @@ export function SplitApp() {
   const rootRef = useRef<HTMLDivElement | null>(null);
   const activeModalRef = useRef<HTMLElement | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Single poll site for backend maintenance/degraded status (#934). The
+  // result is threaded down to SplitAppLegacy via a prop rather than having
+  // individual components poll independently.
+  const { status: maintenanceStatus, isWriteDisabled, message: maintenanceMessage } =
+    useMaintenanceStatus();
 
   const copy = useMemo(
     () =>
@@ -126,7 +134,15 @@ export function SplitApp() {
 
   return (
     <div ref={rootRef}>
-      <SplitAppLegacy onLoadingFlagsChange={onLoadingFlagsChange} />
+      <MaintenanceBanner
+        status={maintenanceStatus}
+        message={maintenanceMessage}
+        className="mx-auto mb-6 w-full max-w-4xl"
+      />
+      <SplitAppLegacy
+        onLoadingFlagsChange={onLoadingFlagsChange}
+        isWriteDisabled={isWriteDisabled}
+      />
     </div>
   );
 }

--- a/frontend/src/hooks/useMaintenanceStatus.test.ts
+++ b/frontend/src/hooks/useMaintenanceStatus.test.ts
@@ -1,0 +1,207 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useMaintenanceStatus } from "./useMaintenanceStatus";
+import * as api from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  getSystemStatus: vi.fn(),
+}));
+
+describe("useMaintenanceStatus", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(api.getSystemStatus).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with a safe 'ok' default before the first poll resolves", () => {
+    vi.mocked(api.getSystemStatus).mockImplementation(() => new Promise(() => {}));
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    expect(result.current.status).toBe("ok");
+    expect(result.current.isWriteDisabled).toBe(false);
+  });
+
+  it("fetches status once on mount", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValue({ status: "ok" });
+
+    renderHook(() => useMaintenanceStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls on the given interval and stops after unmount", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValue({ status: "ok" });
+
+    const { unmount } = renderHook(() => useMaintenanceStatus(10_000));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(3);
+
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    // No further calls after unmount — the polling interval was cleared.
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("defaults to a 30s poll interval when none is provided", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValue({ status: "ok" });
+
+    renderHook(() => useMaintenanceStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(29_999);
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(api.getSystemStatus).toHaveBeenCalledTimes(2);
+  });
+
+  // ── Entering maintenance mode ──────────────────────────────────────────
+
+  it("flips from ok to maintenance mid-poll and disables writes", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValueOnce({ status: "ok" });
+
+    const { result } = renderHook(() => useMaintenanceStatus(5_000));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("ok");
+    expect(result.current.isWriteDisabled).toBe(false);
+
+    vi.mocked(api.getSystemStatus).mockResolvedValueOnce({
+      status: "maintenance",
+      message: "Scheduled maintenance in progress.",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(result.current.status).toBe("maintenance");
+    expect(result.current.isWriteDisabled).toBe(true);
+    expect(result.current.message).toBe("Scheduled maintenance in progress.");
+  });
+
+  it("marks 'degraded' as informational only — writes stay enabled", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValue({
+      status: "degraded",
+      message: "A dependency is unhealthy.",
+    });
+
+    const { result } = renderHook(() => useMaintenanceStatus());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.status).toBe("degraded");
+    expect(result.current.isWriteDisabled).toBe(false);
+  });
+
+  // ── Leaving maintenance mode ────────────────────────────────────────────
+
+  it("flips from maintenance back to ok and re-enables writes", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValueOnce({
+      status: "maintenance",
+      message: "Down for maintenance.",
+    });
+
+    const { result } = renderHook(() => useMaintenanceStatus(5_000));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("maintenance");
+    expect(result.current.isWriteDisabled).toBe(true);
+
+    vi.mocked(api.getSystemStatus).mockResolvedValueOnce({ status: "ok" });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(result.current.status).toBe("ok");
+    expect(result.current.isWriteDisabled).toBe(false);
+    expect(result.current.message).toBeUndefined();
+  });
+
+  it("fails open to 'ok' if a poll tick rejects", async () => {
+    vi.mocked(api.getSystemStatus).mockResolvedValueOnce({
+      status: "maintenance",
+    });
+
+    const { result } = renderHook(() => useMaintenanceStatus(5_000));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("maintenance");
+
+    vi.mocked(api.getSystemStatus).mockRejectedValueOnce(new Error("boom"));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(result.current.status).toBe("ok");
+    expect(result.current.isWriteDisabled).toBe(false);
+  });
+
+  it("does not update state after unmount even if an in-flight poll resolves later", async () => {
+    let resolvePoll: ((value: { status: "ok" | "degraded" | "maintenance" }) => void) | null =
+      null;
+    vi.mocked(api.getSystemStatus).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePoll = resolve;
+        }),
+    );
+
+    const { result, unmount } = renderHook(() => useMaintenanceStatus());
+    unmount();
+
+    await act(async () => {
+      resolvePoll?.({ status: "maintenance" });
+      await Promise.resolve();
+    });
+
+    // Hook result is frozen at its last rendered value; no error should be
+    // thrown from a "setState after unmount" attempt.
+    expect(result.current.status).toBe("ok");
+  });
+});

--- a/frontend/src/hooks/useMaintenanceStatus.ts
+++ b/frontend/src/hooks/useMaintenanceStatus.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { getSystemStatus } from "@/lib/api";
+import type { SystemStatus } from "@/lib/api-client";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export interface UseMaintenanceStatusResult {
+  /** Raw status as reported by (a tolerant mapping of) the backend health endpoint. */
+  status: SystemStatus;
+  /**
+   * Whether write actions should be disabled.
+   *
+   * Design choice: "degraded" is informational only — reads and writes both
+   * keep working, the banner is just a heads-up. "maintenance" additionally
+   * disables writes while leaving read-only flows unaffected, matching the
+   * issue's "without blocking unaffected read-only flows" requirement.
+   */
+  isWriteDisabled: boolean;
+  /** Optional human-readable detail from the backend, shown in the banner. */
+  message?: string;
+}
+
+/**
+ * Polls the backend health/status endpoint on an interval and exposes a
+ * simplified maintenance-mode signal for the UI.
+ *
+ * A single call to this hook should live at the app/SPA root, with the
+ * result threaded down via props (or context) rather than every component
+ * polling independently.
+ */
+export function useMaintenanceStatus(
+  pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+): UseMaintenanceStatusResult {
+  const [status, setStatus] = useState<SystemStatus>("ok");
+  const [message, setMessage] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkStatus = async () => {
+      try {
+        const result = await getSystemStatus();
+        if (cancelled) return;
+        setStatus(result.status);
+        setMessage(result.message);
+      } catch {
+        // getSystemStatus is documented to fail open and not throw, but
+        // guard anyway so a poll tick can never crash the app.
+        if (!cancelled) {
+          setStatus("ok");
+          setMessage(undefined);
+        }
+      }
+    };
+
+    void checkStatus();
+
+    const interval = setInterval(() => {
+      void checkStatus();
+    }, pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [pollIntervalMs]);
+
+  return {
+    status,
+    isWriteDisabled: status === "maintenance",
+    message,
+  };
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -90,6 +90,36 @@ export interface UnallocatedBalanceState {
   unallocated: string;
 }
 
+/**
+ * Simplified frontend-side system status, derived from the backend health
+ * endpoint response.
+ *
+ * ── ASSUMED BACKEND CONTRACT (not yet merged upstream) ──────────────────────
+ * As of this writing, `GET /health` (aliased `/health/ready`) returns
+ * `{ status: "ready" | "not_ready", error?, message?, issues?, requestId? }`
+ * with a 503 on `not_ready`. A parallel, separate piece of work is adding a
+ * three-way `"ready" | "degraded" | "not_ready"` status (200 for
+ * ready/degraded, 503 for not_ready) for a dependency-level breakdown. That
+ * work is unmerged, so its exact final shape is unknown here — this is a
+ * best-guess, tolerant mapping, not a byte-for-byte match to what the
+ * backend ultimately ships:
+ *   - "ready" / "ok"        -> "ok"          (fully operational)
+ *   - "degraded"            -> "degraded"    (banner only; reads AND writes
+ *                                             still work)
+ *   - "not_ready" / "maintenance" / an unrecognized body on a 503
+ *                           -> "maintenance" (banner + writes disabled;
+ *                                             reads keep working)
+ * Anything else (network error, timeout, unparseable JSON, unexpected
+ * shape on a 2xx) fails open to "ok" so a broken health check never itself
+ * breaks the app.
+ */
+export type SystemStatus = "ok" | "degraded" | "maintenance";
+
+export interface SystemStatusResponse {
+  status: SystemStatus;
+  message?: string;
+}
+
 interface BuildSplitResponse {
   xdr: string;
   metadata: {
@@ -484,6 +514,66 @@ export class ApiClient {
       "Failed to fetch unallocated balance",
     );
   }
+
+  /**
+   * Fetches the backend's health/status endpoint and maps it to the
+   * frontend's simplified `SystemStatus`. Never throws — a network error,
+   * timeout, or unparseable response resolves to `{ status: "ok" }` (fail
+   * open) rather than surfacing a fake maintenance banner because the
+   * health check itself is broken. See `SystemStatusResponse` above for the
+   * assumed backend contract this maps from.
+   */
+  async getSystemStatus(): Promise<SystemStatusResponse> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5_000);
+    try {
+      const response = await fetch(`${this.baseUrl}/health`, {
+        signal: controller.signal,
+      });
+      const body = (await response.json().catch(() => null)) as unknown;
+      return normalizeSystemStatus(body, response.status);
+    } catch {
+      // Network error, timeout, or abort — fail open rather than block the app.
+      return { status: "ok" };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+/**
+ * Maps a raw `/health` response body (of whichever shape the backend
+ * happens to send) to the frontend's simplified `SystemStatus`. Tolerant of
+ * a missing/unexpected shape — falls open to "ok" unless the HTTP status
+ * itself signals an outage (503).
+ */
+function normalizeSystemStatus(
+  body: unknown,
+  httpStatus: number,
+): SystemStatusResponse {
+  if (!body || typeof body !== "object") {
+    return httpStatus === 503 ? { status: "maintenance" } : { status: "ok" };
+  }
+
+  const b = body as Record<string, unknown>;
+  const rawStatus =
+    typeof b.status === "string" ? b.status.toLowerCase() : "";
+  const message = typeof b.message === "string" ? b.message : undefined;
+
+  if (rawStatus === "ready" || rawStatus === "ok") {
+    return { status: "ok", message };
+  }
+  if (rawStatus === "degraded") {
+    return { status: "degraded", message };
+  }
+  if (rawStatus === "not_ready" || rawStatus === "maintenance") {
+    return { status: "maintenance", message };
+  }
+
+  // Unrecognized status string: defer to the HTTP status code.
+  return httpStatus === 503
+    ? { status: "maintenance", message }
+    : { status: "ok", message };
 }
 
 function mapProjectToCamelCase(p: Record<string, unknown>): SplitProject {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -11,6 +11,8 @@ export {
   type WithdrawUnallocatedPayload,
   type WithdrawUnallocatedResponse,
   type ListProjectsParams,
+  type SystemStatus,
+  type SystemStatusResponse,
 } from "./api-client";
 
 import { ApiClient, type ListProjectsParams } from "./api-client";
@@ -153,4 +155,8 @@ export async function getAdminTokenCount(): Promise<{ count: number }> {
 
 export async function getUnallocatedBalance(token: string): Promise<{ token: string; unallocated: string }> {
   return client.getUnallocatedBalance(token);
+}
+
+export async function getSystemStatus(): Promise<SystemStatusResponse> {
+  return client.getSystemStatus();
 }


### PR DESCRIPTION
## Summary
- No maintenance-mode concept existed in the frontend — implemented the feature (status hook, banner, write-gate) alongside its tests, since the acceptance criteria required testing behavior that didn't exist yet
- `getSystemStatus()` (new, in `api-client.ts`) polls `GET /health`, tolerantly mapping to `{status: "ok"|"degraded"|"maintenance", message?}` — fails open to `"ok"` on any network/parse error so a broken health check never breaks the app
- `useMaintenanceStatus()` polls every 30s (configurable); `degraded` is informational-only (banner, reads/writes both still work), `maintenance` additionally sets `isWriteDisabled: true` — satisfying "without blocking unaffected read-only flows"
- `MaintenanceBanner` rendered once at the SPA-root (`split-app.tsx`), threaded down via a prop; the real "Execute Payout" button in the distribute-confirmation modal (`split-app-legacy.tsx`) is gated as the demonstrative write-action example
- Deliberately did not touch `ProjectsList.tsx` (a different, unmerged fork's PR touches that file)

## Acceptance criteria
- [x] Mock maintenance status response
- [x] Concise banner on affected routes (SPA-root insertion)
- [x] Disable write actions when maintenance requires it
- [x] Tests for entering and leaving maintenance mode

## Test plan
- [x] `useMaintenanceStatus.test.ts` — 9/9 passing
- [x] `MaintenanceBanner.test.tsx` — 7/7 passing
- [x] New `split-app.test.tsx` write-gate tests — fail alongside all 26 pre-existing tests in that file due to a pre-existing, unrelated `NextIntlClientProvider` bug (confirmed via `git stash`: identical 26/26 failures before this change)
- [x] Full suite: baseline (stashed) 47 failed/168 passed → with change 51 failed/184 passed — the +4 failures are exactly the new tests in the already-100%-broken file; zero previously-passing tests regressed
- [x] Scoped lint clean on all changed/new files

closes #934 