### PR TITLE
feat(backend): add degraded-mode health response contract (#935)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,13 @@ SIMULATOR_ACCOUNT=
 # READ_CACHE_TTL_MS=30000
 # READ_CACHE_MAX_ENTRIES=500
 # DATABASE_POOL_MAX=10
+
+# Degraded-mode health thresholds (optional, Issue #935)
+# GET /health/ready reports a dependency as "degraded" (still 200, not 503)
+# when it responds successfully but slower than these thresholds; it reports
+# "down" (503) only on an outright error/timeout. See docs/runbooks/observability.md.
+# HEALTH_DB_DEGRADED_LATENCY_MS=500
+# HEALTH_RPC_DEGRADED_LATENCY_MS=1500
 // SplitNaira is in active development. This repo currently contains:
 
 // - `contracts/` Soroban smart contract and tests

--- a/backend/src/openapi.ts
+++ b/backend/src/openapi.ts
@@ -1175,20 +1175,72 @@ registry.registerPath({
 const HealthResponseSchema = registry.register(
   "HealthResponse",
   z.object({
-    status: z.enum(["ok", "not_ready"]),
+    status: z.enum(["ok", "degraded", "not_ready"]),
     uptime: z.number().optional().describe("Server uptime in seconds"),
     timestamp: z.string().optional().describe("ISO 8601 timestamp"),
+  })
+);
+
+// Issue #935: per-dependency 3-way status. A dependency is "up" if it
+// responds within its configured latency threshold, "degraded" if it
+// responds successfully but slower than that threshold, and "down" if it
+// errors or times out outright. Thresholds are configurable via
+// HEALTH_DB_DEGRADED_LATENCY_MS (default 500ms) and
+// HEALTH_RPC_DEGRADED_LATENCY_MS (default 1500ms, applied to both the
+// Soroban RPC and contract-simulation checks).
+const ComponentHealthSchema = registry.register(
+  "ComponentHealth",
+  z.object({
+    status: z.enum(["up", "degraded", "down"]),
+    latencyMs: z.number().optional().describe("Round-trip latency of the underlying check, in milliseconds"),
+    message: z
+      .string()
+      .optional()
+      .describe("Redacted, human-readable detail. Never contains secrets or raw connection strings."),
+  })
+);
+
+const EnvComponentHealthSchema = registry.register(
+  "EnvComponentHealth",
+  z.object({
+    ok: z.boolean().describe("Whether required environment variables are present and valid"),
+  })
+);
+
+const EventListenerComponentHealthSchema = registry.register(
+  "EventListenerComponentHealth",
+  z.object({
+    status: z.enum(["stopped", "healthy", "degraded"]),
+    lastSuccessfulPoll: z.string().nullable().describe("ISO 8601 timestamp of the last successful poll, or null"),
+    consecutiveErrors: z.number().int().describe("Number of consecutive failing polls"),
+  })
+);
+
+const ReadinessComponentsSchema = registry.register(
+  "ReadinessComponents",
+  z.object({
+    env: EnvComponentHealthSchema,
+    db: ComponentHealthSchema,
+    rpc: ComponentHealthSchema,
+    contract: ComponentHealthSchema,
+    eventListener: EventListenerComponentHealthSchema.optional(),
   })
 );
 
 const ReadinessResponseSchema = registry.register(
   "ReadinessResponse",
   z.object({
-    status: z.enum(["ready", "not_ready"]),
+    status: z.enum(["ready", "degraded", "not_ready"]).describe(
+      "Issue #935 status/status-code policy: \"ready\" -> 200 (all dependencies up); " +
+      "\"degraded\" -> 200 (service still usable, but at least one dependency is slow " +
+      "or in a non-fatal failure state - investigate, don't page); \"not_ready\" -> 503 " +
+      "(env invalid or a dependency is fully down, unchanged from the legacy binary contract)."
+    ),
     error: z.string().optional().describe("Error code if not ready"),
     message: z.string().optional().describe("Error message if not ready"),
     issues: z.array(z.string()).optional().describe("List of configuration issues"),
     requestId: z.string().optional().describe("Request ID for tracing"),
+    components: ReadinessComponentsSchema.optional(),
   })
 );
 
@@ -1196,10 +1248,13 @@ registry.registerPath({
   method: "get",
   path: "/health",
   summary: "Get readiness status (alias for /health/ready)",
+  description:
+    "Alias for /health/ready. Returns 200 for both \"ready\" and \"degraded\" (service still usable); " +
+    "503 only for \"not_ready\" (Issue #935).",
   tags: ["Health"],
   responses: {
     200: {
-      description: "Server is ready to accept traffic",
+      description: "Server is ready to accept traffic, or degraded but still usable",
       content: {
         "application/json": {
           schema: ReadinessResponseSchema,
@@ -1240,20 +1295,23 @@ registry.registerPath({
   method: "get",
   path: "/health/ready",
   summary: "Readiness check (Kubernetes compatible)",
+  description:
+    "Issue #935: returns 200 with status \"ready\" (all dependencies up) or \"degraded\" " +
+    "(usable, but db/rpc/contract/eventListener is slow or non-fatally impaired); " +
+    "returns 503 with status \"not_ready\" only when env is invalid or a dependency is " +
+    "fully down. See docs/runbooks/observability.md for the on-call interpretation of each state.",
   tags: ["Health"],
   responses: {
     200: {
-      description: "Server is ready to accept traffic",
+      description: "Server is ready to accept traffic, or degraded but still usable",
       content: {
         "application/json": {
-          schema: z.object({
-            status: z.literal("ready"),
-          }),
+          schema: ReadinessResponseSchema,
         },
       },
     },
     503: {
-      description: "Server is not ready (missing configuration)",
+      description: "Server is not ready (missing configuration or a dependency is down)",
       content: {
         "application/json": {
           schema: ReadinessResponseSchema,

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,0 +1,248 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Issue #935: unit-level tests for the degraded-mode health response
+// contract. These mock getDataSource()/checkSorobanReachability() directly
+// (no real Postgres/RPC connection) so "slow but successful" states can be
+// simulated deterministically and the suite runs locally without CI-only
+// dependencies. See src/__tests__/health.ready.integration.test.ts for the
+// real-Postgres integration counterpart (CI-gated).
+//
+// EventListenerService.js is mocked without `importOriginal` so this suite
+// never has to load/transform the real module.
+
+vi.mock("../services/database.js", () => ({
+  getDataSource: vi.fn(),
+}));
+
+vi.mock("../services/stellar.js", () => ({
+  checkSorobanReachability: vi.fn(),
+}));
+
+vi.mock("../services/EventListenerService.js", () => ({
+  getServiceHealth: vi.fn(),
+}));
+
+vi.mock("../config/env.js", () => ({
+  getEnvDiagnostics: vi.fn(),
+}));
+
+import { getDataSource } from "../services/database.js";
+import { checkSorobanReachability } from "../services/stellar.js";
+import { getServiceHealth } from "../services/EventListenerService.js";
+import { getEnvDiagnostics } from "../config/env.js";
+import { requestIdMiddleware } from "../middleware/request-id.js";
+import { errorHandler } from "../middleware/error.js";
+import {
+  healthRouter,
+  markStartupComplete,
+  resetStartupComplete,
+} from "./health.js";
+
+function buildApp() {
+  const app = express();
+  app.use(requestIdMiddleware);
+  app.use("/health", healthRouter);
+  app.use(errorHandler);
+  return app;
+}
+
+const app = buildApp();
+
+// Fixture "secrets" - if any of these literal strings show up anywhere in a
+// response body, that's a leak. Deliberately shaped like real config values
+// (a full Postgres DSN with embedded credentials, an RPC URL with an
+// API-key-looking path segment) so the redaction test is meaningful.
+const FIXTURE_DATABASE_URL = "postgresql://dbuser:sup3rSecretPW@db.internal.example:5432/splitnaira";
+const FIXTURE_RPC_URL = "https://rpc.example.com/v1/apikey_abc123SECRET";
+
+function mockDb(query: () => Promise<unknown>) {
+  vi.mocked(getDataSource).mockReturnValue({
+    isInitialized: true,
+    query,
+  } as unknown as ReturnType<typeof getDataSource>);
+}
+
+function mockFastDb() {
+  mockDb(() => Promise.resolve([{ one: 1 }]));
+}
+
+function mockSlowDb(delayMs: number) {
+  mockDb(
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve([{ one: 1 }]), delayMs);
+      })
+  );
+}
+
+function mockDownDb(message: string) {
+  mockDb(() => Promise.reject(new Error(message)));
+}
+
+function mockFastRpc() {
+  vi.mocked(checkSorobanReachability).mockResolvedValue({
+    rpc: { ok: true, latencyMs: 10 },
+    contract: { ok: true, latencyMs: 10 },
+  });
+}
+
+describe("GET /health/ready - degraded health contract (Issue #935)", () => {
+  beforeEach(() => {
+    markStartupComplete();
+    vi.mocked(getEnvDiagnostics).mockReturnValue({ ok: true });
+    vi.mocked(getServiceHealth).mockReturnValue({
+      status: "healthy",
+      lastSuccessfulPoll: new Date().toISOString(),
+      consecutiveErrors: 0,
+    });
+    delete process.env.HEALTH_DB_DEGRADED_LATENCY_MS;
+    delete process.env.HEALTH_RPC_DEGRADED_LATENCY_MS;
+    process.env.DATABASE_URL = FIXTURE_DATABASE_URL;
+    process.env.SOROBAN_RPC_URL = FIXTURE_RPC_URL;
+  });
+
+  afterEach(() => {
+    resetStartupComplete();
+    vi.resetAllMocks();
+    delete process.env.HEALTH_DB_DEGRADED_LATENCY_MS;
+    delete process.env.HEALTH_RPC_DEGRADED_LATENCY_MS;
+    delete process.env.DATABASE_URL;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("is fully ready: 200, all components up", async () => {
+    mockFastDb();
+    mockFastRpc();
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("ready");
+    expect(res.body.components.env.ok).toBe(true);
+    expect(res.body.components.db).toMatchObject({ status: "up" });
+    expect(res.body.components.rpc).toMatchObject({ status: "up" });
+    expect(res.body.components.contract).toMatchObject({ status: "up" });
+    expect(res.body.components.eventListener.status).toBe("healthy");
+  });
+
+  it("is degraded via a slow database: 200, db degraded, overall degraded", async () => {
+    process.env.HEALTH_DB_DEGRADED_LATENCY_MS = "5";
+    mockSlowDb(40);
+    mockFastRpc();
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.components.db.status).toBe("degraded");
+    expect(res.body.components.db.latencyMs).toBeGreaterThanOrEqual(30);
+    // Unaffected dependencies stay "up".
+    expect(res.body.components.rpc.status).toBe("up");
+  });
+
+  it("is degraded via a slow Soroban RPC: 200, rpc degraded, overall degraded", async () => {
+    mockFastDb();
+    process.env.HEALTH_RPC_DEGRADED_LATENCY_MS = "5";
+    vi.mocked(checkSorobanReachability).mockResolvedValue({
+      rpc: { ok: true, latencyMs: 50 },
+      contract: { ok: true, latencyMs: 3 },
+    });
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.components.rpc.status).toBe("degraded");
+    expect(res.body.components.rpc.latencyMs).toBe(50);
+    expect(res.body.components.contract.status).toBe("up");
+  });
+
+  it("is degraded when only the background event listener is degraded", async () => {
+    mockFastDb();
+    mockFastRpc();
+    vi.mocked(getServiceHealth).mockReturnValue({
+      status: "degraded",
+      lastSuccessfulPoll: null,
+      consecutiveErrors: 3,
+    });
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.components.eventListener.status).toBe("degraded");
+  });
+
+  it("is not_ready via database down: 503 (unchanged existing behavior)", async () => {
+    mockDownDb(`connection error near ${FIXTURE_DATABASE_URL}`);
+    mockFastRpc();
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.error).toBe("database_unavailable");
+    expect(res.body.components.db.status).toBe("down");
+  });
+
+  it("is not_ready via Soroban RPC down: 503 (unchanged existing behavior)", async () => {
+    mockFastDb();
+    vi.mocked(checkSorobanReachability).mockResolvedValue({
+      rpc: { ok: false, message: `unreachable: ${FIXTURE_RPC_URL}` },
+      contract: { ok: false, message: "Skipped because Soroban RPC is unreachable" },
+    });
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.error).toBe("rpc_unavailable");
+    expect(res.body.components.rpc.status).toBe("down");
+  });
+
+  it("is not_ready via contract simulation down: 503 (unchanged existing behavior)", async () => {
+    mockFastDb();
+    vi.mocked(checkSorobanReachability).mockResolvedValue({
+      rpc: { ok: true, latencyMs: 12 },
+      contract: { ok: false, message: "contract not found" },
+    });
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.error).toBe("contract_unreachable");
+    expect(res.body.components.contract.status).toBe("down");
+  });
+
+  it("is not_ready when env diagnostics are invalid (unchanged existing behavior)", async () => {
+    vi.mocked(getEnvDiagnostics).mockReturnValue({
+      ok: false,
+      issues: [{ key: "DATABASE_URL", message: "invalid" }],
+    });
+
+    const res = await request(app).get("/health/ready");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("not_ready");
+    expect(res.body.error).toBe("missing_config");
+  });
+
+  it("never leaks DATABASE_URL / RPC endpoint / credentials into dependency messages", async () => {
+    mockDownDb(`password authentication failed, dsn=${FIXTURE_DATABASE_URL}`);
+    vi.mocked(checkSorobanReachability).mockResolvedValue({
+      rpc: { ok: false, message: `could not reach ${FIXTURE_RPC_URL}` },
+      contract: { ok: false, message: "Skipped because Soroban RPC is unreachable" },
+    });
+
+    const res = await request(app).get("/health/ready");
+    const serialized = JSON.stringify(res.body);
+
+    expect(serialized).not.toContain(FIXTURE_DATABASE_URL);
+    expect(serialized).not.toContain(FIXTURE_RPC_URL);
+    expect(serialized).not.toContain("sup3rSecretPW");
+    expect(serialized).not.toContain("apikey_abc123SECRET");
+  });
+});

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -73,13 +73,108 @@ healthRouter.get("/startup", (_req, res) => {
  */
 healthRouter.get("/ready", handleReadiness);
 
+// ─── Issue #935: degraded-mode health response contract ────────────────────
+//
+// Status code / overall-status policy (documented in docs/runbooks/observability.md):
+//   - "ready"     -> 200. Every dependency is "up" (or "degraded" event
+//                    listener/component logic below doesn't apply).
+//   - "degraded"  -> 200. The service is still usable - every hard-failure
+//                    check below passed - but at least one dependency
+//                    (db/rpc/contract/eventListener) is slow or in a
+//                    non-fatal failure state. Callers should keep routing
+//                    traffic here; on-call should investigate but this is
+//                    not a page-worthy outage on its own.
+//   - "not_ready" -> 503. Unchanged from the previous binary contract: env
+//                    invalid, or db/rpc/contract fully unreachable.
+//
+// A dependency is "up" if it responds successfully within its configured
+// latency threshold, "degraded" if it responds successfully but slower than
+// that threshold, and "down" if it errors or times out entirely. `env` has
+// no natural degraded state (config is either valid or it isn't), so it
+// stays a simple `{ ok: boolean }`.
+
+/** Per-dependency 3-way health status, mirroring EventListenerService's ServiceStatus naming. */
+export type ComponentStatus = "up" | "degraded" | "down";
+
+export interface ComponentHealth {
+  status: ComponentStatus;
+  /** Round-trip latency for the underlying check, in milliseconds, when available. */
+  latencyMs?: number;
+  /** Redacted, human-readable detail. Never contains secrets or raw connection strings. */
+  message?: string;
+}
+
+const DEFAULT_DB_DEGRADED_LATENCY_MS = 500;
+const DEFAULT_RPC_DEGRADED_LATENCY_MS = 1500;
+
+/**
+ * Reads a positive-integer latency threshold from an env var, falling back
+ * to `fallback` when unset or invalid. Read fresh on every request (rather
+ * than cached at module load) so it stays in step with `config/env.js`'s
+ * own "read process.env directly, no restart required for test overrides"
+ * convention and so tests can override it per-case.
+ */
+function readLatencyThresholdMs(envVar: string, fallback: number): number {
+  const raw = process.env[envVar];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getDbDegradedLatencyMs(): number {
+  return readLatencyThresholdMs("HEALTH_DB_DEGRADED_LATENCY_MS", DEFAULT_DB_DEGRADED_LATENCY_MS);
+}
+
+function getRpcDegradedLatencyMs(): number {
+  return readLatencyThresholdMs("HEALTH_RPC_DEGRADED_LATENCY_MS", DEFAULT_RPC_DEGRADED_LATENCY_MS);
+}
+
+/**
+ * Issue #935: dependency-level messages in the readiness response are
+ * public-ish (consumed by orchestrators, and reachable by anyone who can hit
+ * the endpoint), so any secret that a driver/RPC error message might echo
+ * back must be scrubbed before it lands in `components.*.message`.
+ *
+ * Redacts:
+ *  - Full literal values of DATABASE_URL / SOROBAN_RPC_URL / HORIZON_URL /
+ *    PAYMENTS_ADMIN_API_KEY, if the underlying error message happens to
+ *    embed them verbatim (e.g. a pg connection error echoing the DSN).
+ *  - Any `scheme://user:pass@host` credential segment, as a defence-in-depth
+ *    fallback for connection strings not caught by the exact-value check
+ *    above (e.g. a differently-cased or partially-normalised URL).
+ */
+function redactSecrets(message: string): string {
+  let redacted = message;
+
+  const literalSecrets = [
+    process.env.DATABASE_URL,
+    process.env.SOROBAN_RPC_URL,
+    process.env.HORIZON_URL,
+    process.env.PAYMENTS_ADMIN_API_KEY
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  for (const secret of literalSecrets) {
+    redacted = redacted.split(secret).join("[REDACTED]");
+  }
+
+  // Generic connection-string credential pattern: scheme://user:pass@host
+  redacted = redacted.replace(/([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^@\s/]+@/g, "$1[REDACTED]@");
+
+  return redacted;
+}
+
 async function handleReadiness(_req: unknown, res: Response, next: NextFunction) {
   const requestId = res.locals.requestId;
-  const components = {
+  const components: {
+    env: { ok: boolean };
+    db: ComponentHealth;
+    rpc: ComponentHealth;
+    contract: ComponentHealth;
+  } = {
     env: { ok: true },
-    db: { ok: false, message: "" },
-    rpc: { ok: false, message: "" },
-    contract: { ok: false, message: "" }
+    db: { status: "down" },
+    rpc: { status: "down" },
+    contract: { status: "down" }
   };
 
   if (shuttingDown) {
@@ -121,6 +216,8 @@ async function handleReadiness(_req: unknown, res: Response, next: NextFunction)
     return;
   }
 
+  const dbDegradedLatencyMs = getDbDegradedLatencyMs();
+
   try {
     const ds = getDataSource();
     if (!ds.isInitialized) {
@@ -128,26 +225,30 @@ async function handleReadiness(_req: unknown, res: Response, next: NextFunction)
     }
 
     try {
+      const dbStart = Date.now();
       const rows = await ds.query('SELECT 1 AS one');
-      components.db = { ok: true, message: 'query_ok', rows: Array.isArray(rows) ? rows.length : undefined };
+      const latencyMs = Date.now() - dbStart;
+      components.db = {
+        status: latencyMs > dbDegradedLatencyMs ? "degraded" : "up",
+        latencyMs,
+        message: Array.isArray(rows) ? "query_ok" : "query_ok_unexpected_shape"
+      };
     } catch (queryErr) {
       const message = queryErr instanceof Error ? queryErr.message : String(queryErr);
-      components.db = { ok: false, message: `query_failed: ${message}` };
+      components.db = { status: "down", message: redactSecrets(`query_failed: ${message}`) };
       res.status(503).json({
         status: "not_ready",
         error: "database_unavailable",
         message: "Database query failed; check DATABASE_URL and connectivity.",
         components,
         requestId,
-        details: { error: message }
+        details: { error: redactSecrets(message) }
       });
       return;
     }
   } catch (dbError) {
-    components.db = {
-      ok: false,
-      message: dbError instanceof Error ? dbError.message : "Database connection is not available."
-    };
+    const message = dbError instanceof Error ? dbError.message : "Database connection is not available.";
+    components.db = { status: "down", message: redactSecrets(message) };
     res.status(503).json({
       status: "not_ready",
       error: "database_unavailable",
@@ -159,13 +260,34 @@ async function handleReadiness(_req: unknown, res: Response, next: NextFunction)
     return;
   }
 
+  const rpcDegradedLatencyMs = getRpcDegradedLatencyMs();
+
   try {
     const soroban = await checkSorobanReachability();
-    components.rpc = { ok: soroban.rpc.ok, message: soroban.rpc.message ?? "reachable" };
-    components.contract = {
-      ok: soroban.contract.ok,
-      message: soroban.contract.message ?? "simulation_ok"
-    };
+
+    components.rpc = soroban.rpc.ok
+      ? {
+          status: (soroban.rpc.latencyMs ?? 0) > rpcDegradedLatencyMs ? "degraded" : "up",
+          latencyMs: soroban.rpc.latencyMs,
+          message: redactSecrets(soroban.rpc.message ?? "reachable")
+        }
+      : {
+          status: "down",
+          latencyMs: soroban.rpc.latencyMs,
+          message: redactSecrets(soroban.rpc.message ?? "unreachable")
+        };
+
+    components.contract = soroban.contract.ok
+      ? {
+          status: (soroban.contract.latencyMs ?? 0) > rpcDegradedLatencyMs ? "degraded" : "up",
+          latencyMs: soroban.contract.latencyMs,
+          message: redactSecrets(soroban.contract.message ?? "simulation_ok")
+        }
+      : {
+          status: "down",
+          latencyMs: soroban.contract.latencyMs,
+          message: redactSecrets(soroban.contract.message ?? "simulation_failed")
+        };
 
     if (!soroban.rpc.ok || !soroban.contract.ok) {
       res.status(503).json({
@@ -185,12 +307,20 @@ async function handleReadiness(_req: unknown, res: Response, next: NextFunction)
 
   // Surface the background event listener's health. A degraded listener (e.g.
   // during a Soroban RPC outage with active back-off) does not make the API
-  // unready for reads, so this is reported informationally rather than failing
-  // the readiness probe.
+  // unready for reads, so it never triggers a 503 here - but (Issue #935) it
+  // now does pull the *overall* status down to "degraded" alongside a slow
+  // db/rpc/contract, since ops should be aware something needs attention even
+  // though traffic keeps flowing.
   const eventListener = getServiceHealth();
 
+  const anyDegraded =
+    components.db.status === "degraded" ||
+    components.rpc.status === "degraded" ||
+    components.contract.status === "degraded" ||
+    eventListener.status === "degraded";
+
   res.json({
-    status: "ready",
+    status: anyDegraded ? "degraded" : "ready",
     version: SERVICE_VERSION,
     components: { ...components, eventListener },
   });

--- a/backend/src/services/stellar.ts
+++ b/backend/src/services/stellar.ts
@@ -328,18 +328,31 @@ export interface SorobanReachabilityStatus {
   rpc: {
     ok: boolean;
     message?: string;
+    /** Issue #935: round-trip time for the `getAccount` call, in milliseconds. */
+    latencyMs?: number;
   };
   contract: {
     ok: boolean;
     message?: string;
+    /** Issue #935: round-trip time for the `simulateTransaction` call, in milliseconds. */
+    latencyMs?: number;
   };
 }
 
+/**
+ * Issue #935: probes Soroban RPC reachability and contract simulation,
+ * capturing latency for each call so the readiness endpoint can distinguish
+ * "reachable but slow" (degraded) from "unreachable" (down). Latency is
+ * measured around the full `executeWithRetry` call (including any retries),
+ * since a caller waiting on this endpoint cares about total wall-clock time,
+ * not just the final attempt.
+ */
 export async function checkSorobanReachability(): Promise<SorobanReachabilityStatus> {
   const config = loadStellarConfig();
   const server = getStellarRpcServer();
 
   let sourceAccount;
+  const rpcStart = Date.now();
   try {
     sourceAccount = await executeWithRetry(() => server.getAccount(config.simulatorAccount), {
       maxRetries: 1,
@@ -350,6 +363,7 @@ export async function checkSorobanReachability(): Promise<SorobanReachabilitySta
     return {
       rpc: {
         ok: false,
+        latencyMs: Date.now() - rpcStart,
         message: error instanceof Error ? error.message : "Soroban RPC account lookup failed"
       },
       contract: {
@@ -358,7 +372,9 @@ export async function checkSorobanReachability(): Promise<SorobanReachabilitySta
       }
     };
   }
+  const rpcLatencyMs = Date.now() - rpcStart;
 
+  const contractStart = Date.now();
   try {
     Address.fromString(config.contractId);
     const contract = new Contract(config.contractId);
@@ -377,16 +393,17 @@ export async function checkSorobanReachability(): Promise<SorobanReachabilitySta
     });
   } catch (error) {
     return {
-      rpc: { ok: true },
+      rpc: { ok: true, latencyMs: rpcLatencyMs },
       contract: {
         ok: false,
+        latencyMs: Date.now() - contractStart,
         message: error instanceof Error ? error.message : "Contract simulation failed"
       }
     };
   }
 
   return {
-    rpc: { ok: true },
-    contract: { ok: true }
+    rpc: { ok: true, latencyMs: rpcLatencyMs },
+    contract: { ok: true, latencyMs: Date.now() - contractStart }
   };
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -143,6 +143,7 @@ components:
           type: string
           enum:
             - ok
+            - degraded
             - not_ready
         uptime:
           type: number
@@ -152,6 +153,70 @@ components:
           description: ISO 8601 timestamp
       required:
         - status
+    ComponentHealth:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - up
+            - degraded
+            - down
+        latencyMs:
+          type: number
+          description: Round-trip latency of the underlying check, in milliseconds
+        message:
+          type: string
+          description: Redacted, human-readable detail. Never contains secrets or raw
+            connection strings.
+      required:
+        - status
+    EnvComponentHealth:
+      type: object
+      properties:
+        ok:
+          type: boolean
+          description: Whether required environment variables are present and valid
+      required:
+        - ok
+    EventListenerComponentHealth:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - stopped
+            - healthy
+            - degraded
+        lastSuccessfulPoll:
+          type: string
+          nullable: true
+          description: ISO 8601 timestamp of the last successful poll, or null
+        consecutiveErrors:
+          type: integer
+          description: Number of consecutive failing polls
+      required:
+        - status
+        - lastSuccessfulPoll
+        - consecutiveErrors
+    ReadinessComponents:
+      type: object
+      properties:
+        env:
+          $ref: "#/components/schemas/EnvComponentHealth"
+        db:
+          $ref: "#/components/schemas/ComponentHealth"
+        rpc:
+          $ref: "#/components/schemas/ComponentHealth"
+        contract:
+          $ref: "#/components/schemas/ComponentHealth"
+        eventListener:
+          $ref: "#/components/schemas/EventListenerComponentHealth"
+      required:
+        - env
+        - db
+        - rpc
+        - contract
     ReadinessResponse:
       type: object
       properties:
@@ -159,7 +224,14 @@ components:
           type: string
           enum:
             - ready
+            - degraded
             - not_ready
+          description: "Issue #935 status/status-code policy: \"ready\" -> 200 (all
+            dependencies up); \"degraded\" -> 200 (service still usable, but at
+            least one dependency is slow or in a non-fatal failure state -
+            investigate, don't page); \"not_ready\" -> 503 (env invalid or a
+            dependency is fully down, unchanged from the legacy binary
+            contract)."
         error:
           type: string
           description: Error code if not ready
@@ -174,6 +246,8 @@ components:
         requestId:
           type: string
           description: Request ID for tracing
+        components:
+          $ref: "#/components/schemas/ReadinessComponents"
       required:
         - status
     MainnetReadinessResponse:
@@ -2913,11 +2987,14 @@ paths:
   /health:
     get:
       summary: Get readiness status (alias for /health/ready)
+      description: 'Alias for /health/ready. Returns 200 for both "ready" and
+        "degraded" (service still usable); 503 only for "not_ready" (Issue
+        #935).'
       tags:
         - Health
       responses:
         "200":
-          description: Server is ready to accept traffic
+          description: Server is ready to accept traffic, or degraded but still usable
           content:
             application/json:
               schema:
@@ -2950,24 +3027,23 @@ paths:
   /health/ready:
     get:
       summary: Readiness check (Kubernetes compatible)
+      description: 'Issue #935: returns 200 with status "ready" (all dependencies up)
+        or "degraded" (usable, but db/rpc/contract/eventListener is slow or
+        non-fatally impaired); returns 503 with status "not_ready" only when env
+        is invalid or a dependency is fully down. See
+        docs/runbooks/observability.md for the on-call interpretation of each
+        state.'
       tags:
         - Health
       responses:
         "200":
-          description: Server is ready to accept traffic
+          description: Server is ready to accept traffic, or degraded but still usable
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum:
-                      - ready
-                required:
-                  - status
+                $ref: "#/components/schemas/ReadinessResponse"
         "503":
-          description: Server is not ready (missing configuration)
+          description: Server is not ready (missing configuration or a dependency is down)
           content:
             application/json:
               schema:

--- a/docs/runbooks/observability.md
+++ b/docs/runbooks/observability.md
@@ -6,16 +6,65 @@ Operational guidance for metrics, health probes, correlation IDs, and deploy ver
 
 | Endpoint | Purpose | Expected |
 |----------|---------|----------|
-| `GET /health` | Basic status + uptime | `200`, `{ status: "ok" }` |
+| `GET /health` | Readiness alias | `200` (`ready`/`degraded`), `503` (`not_ready`) — see below |
 | `GET /health/live` | Liveness (process up) | `200`, `{ status: "ok" }` |
 | `GET /health/startup` | Initialisation complete | `200` after DB/listeners start; `503` during boot |
-| `GET /health/ready` | Ready for traffic | `200` when DB + Soroban RPC + contract sim OK |
+| `GET /health/ready` | Ready for traffic | `200` (`ready`/`degraded`), `503` (`not_ready`) — see below |
 
 Configure Render/orchestrator probes:
 
 - **Liveness:** `/health/live`
 - **Readiness:** `/health/ready`
 - **Startup (optional):** `/health/startup`
+
+### Degraded-mode readiness contract (Issue #935)
+
+`/health` and `/health/ready` report a three-way `status` instead of a binary
+ready/not-ready, so orchestrators and the frontend can distinguish "fully
+healthy", "impaired but serving traffic", and "actually down":
+
+| `status` | HTTP code | Meaning | On-call action |
+|----------|-----------|---------|-----------------|
+| `ready` | `200` | Every dependency (`db`, `rpc`, `contract`, `eventListener`) is `up`/`healthy`. | None. |
+| `degraded` | `200` | The service is still usable — nothing is fully down — but at least one dependency is slow (past its latency threshold) or in a non-fatal failure state (e.g. the event listener backing off after RPC errors). | Investigate at normal priority; **do not page as an outage**. Traffic keeps flowing. |
+| `not_ready` | `503` | `env` config is invalid, or `db`/`rpc`/`contract` is fully unreachable/erroring. Unchanged from the legacy binary contract. | Page / treat as an outage, same as before. |
+
+Each of `components.db`, `components.rpc`, and `components.contract` in the
+response body now has the shape:
+
+```json
+{ "status": "up" | "degraded" | "down", "latencyMs": 123, "message": "query_ok" }
+```
+
+- **`up`**: responded successfully within its latency threshold.
+- **`degraded`**: responded successfully, but slower than its threshold.
+- **`down`**: errored or timed out outright (this is what drives `not_ready`/`503` — a dependency degrading to `"degraded"` never does).
+
+`components.env` stays a simple `{ ok: boolean }` — there's no natural
+"degraded" config state. `components.eventListener` keeps its existing
+`stopped`/`healthy`/`degraded` shape from `EventListenerService.getServiceHealth()`;
+an `eventListener.status === "degraded"` now also pulls the *overall*
+`status` down to `"degraded"` (previously it was reported informationally
+without affecting the top-level status).
+
+**Latency thresholds** (configurable, see `backend/.env.example`):
+
+| Env var | Default | Applies to |
+|---------|---------|------------|
+| `HEALTH_DB_DEGRADED_LATENCY_MS` | `500` | The `SELECT 1` readiness query |
+| `HEALTH_RPC_DEGRADED_LATENCY_MS` | `1500` | Both the Soroban RPC `getAccount` reachability call and the contract-simulation call |
+
+Defaults were picked to be well above typical same-region latency (a local
+Postgres `SELECT 1` is normally single-digit ms; a Soroban RPC round-trip is
+normally 100-500ms) while still catching genuine slowdowns before they turn
+into timeouts/retries and user-visible errors.
+
+**Secrets hygiene**: dependency `message` fields are redacted before being
+serialized — literal `DATABASE_URL`/`SOROBAN_RPC_URL`/`HORIZON_URL`/
+`PAYMENTS_ADMIN_API_KEY` values and any `scheme://user:pass@host`-shaped
+credential segment are stripped to `[REDACTED]` if a driver or RPC error
+happens to echo them back. See `redactSecrets()` in `backend/src/routes/health.ts`
+and the redaction test in `backend/src/routes/health.test.ts`.
 
 ## Metrics
 
@@ -68,7 +117,10 @@ When `BACKEND_METRICS_URL` is also configured, the smoke check validates the ana
 
 1. Obtain `x-correlation-id` / `requestId` from the client or error response.
 2. Search Render logs or Sentry (when `SENTRY_DSN` is configured).
-3. Check `/health/ready` component breakdown for dependency failures.
+3. Check `/health/ready` component breakdown for dependency failures — note
+   whether the overall `status` is `degraded` (investigate, don't page) or
+   `not_ready` (treat as an outage); see "Degraded-mode readiness contract"
+   above.
 4. Review metrics around the failure window (`splitnaira_validation_failures_total` spikes indicate schema drift).
 
 ## Rollback

--- a/docs/runbooks/reliability.md
+++ b/docs/runbooks/reliability.md
@@ -15,7 +15,16 @@ GET /health/ready
 Checks:
 
 - PostgreSQL
-- Redis
+- Soroban RPC + contract simulation
+
+Returns one of three states (Issue #935 — full contract and per-component
+shape documented in [`observability.md`](./observability.md#degraded-mode-readiness-contract-issue-935)):
+
+- `ready` (`200`) — everything healthy.
+- `degraded` (`200`) — still serving traffic, but a dependency is slow or the
+  background event listener is in an error back-off. Investigate, don't page.
+- `not_ready` (`503`) — a dependency is fully down or config is invalid.
+  Unchanged from the previous binary contract.
 
 ### Startup
 
@@ -36,9 +45,13 @@ Checks startup completion and uptime.
 
 ## Incident Response
 
-If readiness fails:
+If readiness returns `not_ready` (`503`):
 
 - Check PostgreSQL availability
-- Check Redis availability
+- Check Soroban RPC / contract simulation availability
 - Inspect application logs
 - Verify deployment secrets
+
+If readiness returns `degraded` (`200`): traffic is still being served. Check
+the slow/impaired component(s) in the response body, but this does not need
+page-level urgency on its own — see `observability.md`.


### PR DESCRIPTION
## Summary
- Extends the real, live Express health router (`routes/health.ts`) — confirmed the parallel NestJS `health/health.controller.ts`/`health.service.ts` files are dead scaffolding, never wired into the app, and left untouched
- New 3-way component shape `{status: "up"|"degraded"|"down", latencyMs?, message?}` for `db`/`rpc`/`contract`; configurable latency thresholds (`HEALTH_DB_DEGRADED_LATENCY_MS` default 500ms, `HEALTH_RPC_DEGRADED_LATENCY_MS` default 1500ms)
- Status/code policy: `not_ready`→503 (identical trigger conditions to today — zero loosening of failure detection), `degraded`→200, `ready`→200
- `redactSecrets()` strips `DATABASE_URL`/`SOROBAN_RPC_URL`/`HORIZON_URL`/`PAYMENTS_ADMIN_API_KEY` values and generic `scheme://user:pass@host` patterns from every dependency message before serialization — verified with a dedicated test
- OpenAPI: updated `backend/src/openapi.ts`'s schemas/paths, regenerated `docs/openapi.yaml` via `npm run generate:openapi`; the drift-check test (`openapi.test.ts`) passes. (`docs/openapi.json` is a separate, already-stale, CI-unreferenced artifact — left untouched, matching the "never hand-edit generated files" rule since neither the generator nor the drift check touch it.)
- Updated `docs/runbooks/observability.md` and `docs/runbooks/reliability.md` (not `docs/RELEASE_RUNBOOK.md`, which a different, unmerged fork's PR touches) with the new contract, thresholds, and paging guidance (page on `not_ready`, investigate-don't-page on `degraded`)

## Acceptance criteria
- [x] Degraded response shape and status-code policy defined
- [x] Dependency-level details without leaking secrets (tested explicitly)
- [x] Tests for RPC degraded and database degraded states
- [x] OpenAPI and runbooks updated

## Test plan
- [x] `backend/src/routes/health.test.ts` (new) — 9/9 passing
- [x] `openapi.test.ts` drift check — passing
- [x] Full suite: baseline 65 failed/272 passed → with change 65 failed/281 passed (same pre-existing failures, +9 new passing tests, zero regressions)
- [x] Scoped lint clean

## Note — pre-existing bug found (out of scope, flagging for visibility)
`backend/src/services/EventListenerService.ts` has duplicate `const`/variable declarations that fail esbuild's transform, breaking every test file that transitively imports it (~22 files repo-wide). Confirmed pre-existing via `git stash`; worked around it in this PR's own tests by mocking that module without `importOriginal`. Worth a dedicated follow-up fix.

closes #935 