### PR TITLE
Add frontend performance smoke test for dashboard rendering (#936)

### DIFF
--- a/docs/frontend-performance-profiling.md
+++ b/docs/frontend-performance-profiling.md
@@ -1,0 +1,107 @@
+# Frontend Performance Profiling Workflow
+
+This doc covers two things:
+
+1. How to run the dashboard render performance smoke test locally.
+2. How to profile a real render-performance regression if that smoke test
+   ever fails (or a user reports a slow dashboard) using React DevTools /
+   Chrome DevTools against the actual running app.
+
+## 1. Running the performance smoke test
+
+The smoke test lives at
+`frontend/src/components/dashboard/DashboardView.perf.test.tsx`. It renders
+`DashboardView` once with a deterministic 800-project fixture and asserts:
+
+- The render completes within a generous time budget (3000ms — see the
+  comment above the assertion in the test file for the full rationale).
+- The output is actually correct at that scale: the "Total Managed" summary
+  reflects the full fixture count, the first and last projects in the list
+  both appear in the "Project Performance Rollups" table, and every project
+  ID is present exactly once.
+
+Run it on its own:
+
+```sh
+cd frontend
+npx vitest run src/components/dashboard/DashboardView.perf.test.tsx
+```
+
+Or with the verbose reporter, which is useful if you want to see per-test
+timing output:
+
+```sh
+npx vitest run src/components/dashboard/DashboardView.perf.test.tsx --reporter=verbose
+```
+
+This test is part of the regular suite, so `npm run test` from `frontend/`
+also runs it.
+
+### What a failure means
+
+The threshold is intentionally coarse (see the in-file comment), so a
+failure most likely means one of:
+
+- A genuine regression was introduced (e.g. an accidental O(n²) loop over
+  `dashboardData`, a broken memoization boundary causing repeated
+  re-renders, or removal of the one place this table currently gets away
+  without virtualization).
+- The CI runner was unusually slow/contended. If reruns are consistently
+  fast locally and only a shared CI runner trips the threshold, that's a
+  signal to raise the budget, not to chase a phantom regression.
+
+If you suspect a real regression, move on to profiling below.
+
+## 2. Profiling a real regression
+
+The smoke test only tells you *that* something got slower, not *why*. To
+investigate, profile the actual running app rather than the test:
+
+1. Start the dev server from the repo root:
+
+   ```sh
+   npm run dev:frontend
+   ```
+
+   (equivalent to `cd frontend && npm run dev`)
+
+2. Open the dashboard view in the browser with a realistically large
+   dataset (or temporarily point the dashboard at test data matching the
+   shape used in the perf smoke fixture, e.g. several hundred projects).
+
+3. **React DevTools Profiler** (recommended first step):
+   - Install/open the React DevTools browser extension.
+   - Switch to the "Profiler" tab.
+   - Click record, trigger the render you want to inspect (e.g. reload the
+     dashboard, or trigger whatever state change causes a re-render), then
+     stop recording.
+   - Look at the flamegraph/ranked view for `DashboardView` and its
+     children. Wide bars or components that re-render far more often than
+     you'd expect are the usual suspects.
+
+4. **Chrome DevTools Performance tab** (for lower-level detail, e.g. layout
+   thrashing or long tasks that React DevTools doesn't attribute clearly):
+   - Open DevTools → Performance tab.
+   - Click record, trigger the render, stop recording.
+   - Look at the main thread flame chart for long "Scripting" blocks during
+     the render, and check the "Bottom-Up"/"Call Tree" views to see which
+     function is actually consuming the time.
+
+### Known likely bottleneck: the unvirtualized rollups table
+
+The most probable source of any real dashboard render regression is the
+"Project Performance Rollups" table in
+`frontend/src/components/dashboard/DashboardView.tsx`. It `.map()`s over
+the **entire** `dashboardData` array unconditionally, with no pagination,
+no windowing, and one `<tr>` (plus several `sanitizeText()` calls) per
+project. Unlike the "Your Cumulative Earnings" section above it — which
+first `.filter()`s down to the current wallet's projects — this table has
+no upper bound on how many rows it renders.
+
+If profiling confirms this table is the actual bottleneck for a genuine
+large-dataset regression, the natural fix is **list virtualization** (e.g.
+[`react-window`](https://github.com/bvaughn/react-window) or
+[`@tanstack/react-virtual`](https://github.com/TanStack/virtual)) so only
+the rows currently in the viewport are mounted. That is out of scope for
+this issue — this doc is informational, to give the next person a starting
+point rather than requiring them to rediscover it from scratch.

--- a/frontend/src/components/dashboard/DashboardView.perf.test.tsx
+++ b/frontend/src/components/dashboard/DashboardView.perf.test.tsx
@@ -1,0 +1,196 @@
+/* @vitest-environment jsdom */
+
+/**
+ * Performance smoke test for DashboardView.
+ *
+ * See docs/frontend-performance-profiling.md for the local profiling
+ * workflow (React/Chrome DevTools) to use if this test ever fails or a
+ * real regression needs investigating.
+ *
+ * This is intentionally a *smoke* test, not a benchmark: it renders the
+ * dashboard once with a large, fully deterministic fixture and asserts
+ * that render time stays under a deliberately generous ceiling. The goal
+ * is to catch a catastrophic regression (e.g. an accidental O(n^2) loop,
+ * a runaway re-render, or a virtualization removal) before release — not
+ * to enforce a tight performance SLA. Coarse thresholds are used on
+ * purpose to avoid flakiness on slower/shared CI runners.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+
+import { DashboardView } from "./DashboardView";
+import type { AllowlistActionResult } from "./DashboardView";
+import type { SplitProject } from "@/lib/stellar";
+import type { WalletState } from "@/lib/wallet";
+
+// ---------------------------------------------------------------------------
+// Deterministic large fixture
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixture size rationale: 800 projects is well past what any real dashboard
+ * would show today, but small enough to keep this test fast and non-flaky
+ * in CI. The "Project Performance Rollups" table in DashboardView maps over
+ * the entire `dashboardData` array with no virtualization/pagination and no
+ * memoization on a per-row basis, so it renders one `<tr>` (with several
+ * `sanitizeText()` calls each) per project — this is the most likely real
+ * bottleneck for "large project lists," and a count in the hundreds is
+ * enough to plausibly surface an accidental O(n^2) loop or an unnecessary
+ * re-render without making the test itself slow.
+ *
+ * Every field is derived purely from the index `i` (no `Math.random()`, no
+ * wall-clock timestamps), so the fixture — and therefore this test's
+ * behavior — is 100% reproducible across runs and machines.
+ */
+const FIXTURE_SIZE = 800;
+
+const PROJECT_TYPES = ["App", "Content", "Service", "Media"];
+
+function buildCollaborators(projectIndex: number): SplitProject["collaborators"] {
+  // Three collaborators per project, deterministic addresses/aliases, basis
+  // points summing to 10000 (100.00%).
+  return [
+    { address: `GCOLLAB${projectIndex}-0`, alias: `Collaborator ${projectIndex}-0`, basisPoints: 3334 },
+    { address: `GCOLLAB${projectIndex}-1`, alias: `Collaborator ${projectIndex}-1`, basisPoints: 3333 },
+    { address: `GCOLLAB${projectIndex}-2`, alias: `Collaborator ${projectIndex}-2`, basisPoints: 3333 },
+  ];
+}
+
+function buildLargeDashboardFixture(count: number): SplitProject[] {
+  return Array.from({ length: count }, (_, i) => {
+    const project: SplitProject = {
+      projectId: `proj-${i}`,
+      title: `Project ${i}`,
+      projectType: PROJECT_TYPES[i % PROJECT_TYPES.length],
+      token: `TOKEN${i % 5}`,
+      owner: `GOWNER${i}`,
+      collaborators: buildCollaborators(i),
+      locked: i % 7 === 0,
+      totalDistributed: String(i * 500),
+      distributionRound: i % 12,
+      balance: String(i * 1000),
+    };
+    return project;
+  });
+}
+
+const largeFixture = buildLargeDashboardFixture(FIXTURE_SIZE);
+
+function noop() {
+  // intentionally empty
+}
+
+async function asyncNoop(): Promise<void> {
+  // intentionally empty
+}
+
+async function asyncNoopUnknown(): Promise<unknown> {
+  return null;
+}
+
+const disconnectedWallet: WalletState = {
+  connected: false,
+  address: null,
+  network: null,
+};
+
+/**
+ * Baseline props for a "disconnected wallet, non-admin" viewer. This keeps
+ * the admin panels (token allowlist / recovery console / pause control) and
+ * the "Your Cumulative Earnings" section collapsed, so the render exercises
+ * the summary cards plus the unconditional "Project Performance Rollups"
+ * table at full fixture scale — the actual scenario this smoke test targets.
+ */
+function buildBaseProps(dashboardData: SplitProject[]) {
+  return {
+    wallet: disconnectedWallet,
+    isContractAdmin: false,
+    tokenAllowlist: null,
+    isLoadingAllowlist: false,
+    isUpdatingAllowlist: false,
+    allowlistTokenInput: "",
+    setAllowlistTokenInput: noop,
+    isValidAllowlistToken: false,
+    normalizedAllowlistToken: "",
+    onSubmitAllowlistAction: async (_action: "allow" | "disallow") => {},
+    lastAllowlistTx: null as AllowlistActionResult | null,
+    refreshTokenAllowlist: asyncNoopUnknown,
+    isLoadingDashboard: false,
+    dashboardData,
+    userEarnings: {} as Record<string, string>,
+    adminStatus: null,
+    isLoadingAdminStatus: false,
+    refreshAdminStatus: asyncNoopUnknown,
+    showPauseConfirm: false,
+    setShowPauseConfirm: noop,
+    showUnpauseConfirm: false,
+    setShowUnpauseConfirm: noop,
+    isSubmittingPause: false,
+    lastPauseTxHash: null,
+    onTogglePause: async (_action: "pause" | "unpause") => {},
+    recoveryTokenInput: "",
+    setRecoveryTokenInput: noop,
+    isLoadingUnallocated: false,
+    unallocatedError: null,
+    unallocatedBalance: null,
+    onInspectUnallocated: asyncNoop,
+    recoveryToInput: "",
+    setRecoveryToInput: noop,
+    recoveryAmountInput: "",
+    setRecoveryAmountInput: noop,
+    showRecoveryConfirm: false,
+    setShowRecoveryConfirm: noop,
+    isSubmittingRecovery: false,
+    onConfirmRecovery: asyncNoop,
+    lastRecoveryTxHash: null,
+    setActiveTab: noop,
+    setSearchProjectId: noop,
+    setFetchedProject: noop,
+  };
+}
+
+describe("DashboardView performance smoke", () => {
+  it(`renders ${FIXTURE_SIZE} projects within a generous time budget and without truncating data`, () => {
+    const props = buildBaseProps(largeFixture);
+
+    // --- Warmup render (untimed) --------------------------------------
+    // The first render of a test file pays for module init, JSX
+    // compilation caches, jsdom setup, etc. That one-time cost is not
+    // representative of steady-state render performance and is a common
+    // source of flakiness in timing assertions, so we discard it here and
+    // only time the second render.
+    const warmup = render(<DashboardView {...props} />);
+    warmup.unmount();
+    cleanup();
+
+    // --- Timed render ---------------------------------------------------
+    const start = performance.now();
+    render(<DashboardView {...props} />);
+    const elapsedMs = performance.now() - start;
+
+    // Threshold rationale: 3000ms for an 800-row unvirtualized table render
+    // in a jsdom + CI-shared-runner environment is deliberately generous —
+    // typical local runs complete in well under a second. This budget
+    // exists to catch a catastrophic regression (accidental O(n^2) work,
+    // an infinite re-render loop, a virtualization removal that goes very
+    // wrong), not to enforce a tight performance SLA. If this ever flakes
+    // on a legitimately slower CI runner, raise the threshold rather than
+    // optimizing the component under time pressure — see
+    // docs/frontend-performance-profiling.md for how to tell the
+    // difference between "CI is just slow" and "there is a real
+    // regression."
+    const RENDER_BUDGET_MS = 3000;
+    expect(elapsedMs).toBeLessThan(RENDER_BUDGET_MS);
+
+    // --- Correctness at scale --------------------------------------------
+    // A pure timing assertion would still pass if rendering silently
+    // truncated the list, so also assert the output reflects the full
+    // fixture: the summary card count, the first row, and a row near the
+    // end of the (unvirtualized, unpaginated) table.
+    expect(screen.getByText(String(FIXTURE_SIZE))).toBeTruthy();
+    expect(screen.getByText("Project 0")).toBeTruthy();
+    expect(screen.getByText(`Project ${FIXTURE_SIZE - 1}`)).toBeTruthy();
+    expect(screen.getAllByText(/^proj-/).length).toBe(FIXTURE_SIZE);
+  });
+});


### PR DESCRIPTION
## Summary
- Pure test addition — `DashboardView.tsx` itself is unchanged
- Deterministic 800-project fixture (index-derived, no `Math.random()`/timestamps), sized to stress the unvirtualized "Project Performance Rollups" table (`DashboardView.tsx` maps the entire `dashboardData` array with no pagination/virtualization — the real likely bottleneck for large lists)
- Timing: one untimed warmup render (discards JIT/module-init cost) + a `performance.now()`-timed second render, asserted under a deliberately generous 3000ms threshold — real measured renders are ~66ms, so ~45x headroom, intended to catch a catastrophic regression (O(n²), re-render loop) rather than gate on micro-perf
- Correctness-at-scale assertions alongside the timing check (summary count, first/last project rendered, total row count) so a pure timing pass can't mask silent data truncation
- New `docs/frontend-performance-profiling.md`: how to run the smoke test, how to profile a real regression with React/Chrome DevTools against the dev server, and the known likely bottleneck + suggested fix (virtualization, not implemented — informational only)

## Acceptance criteria
- [x] Render dashboard with large deterministic fixtures (800 projects)
- [x] Measure/assert basic render time budget
- [x] Coarse thresholds to avoid flakiness (documented reasoning inline)
- [x] Local profiling workflow documented

## Test plan
- [x] Ran the new test 8 times locally — zero flakiness (65.6–68.3ms observed against a 3000ms threshold)
- [x] Full suite: baseline (stashed) 14 failed files/20 failed tests/157 passed → with change 158 passed — delta is exactly the one new passing file, no regressions
- [x] Scoped lint clean

closes #936 