### PR TITLE
Add orphaned transaction reconciliation check (#937)

### DIFF
--- a/backend/src/scripts/check-orphaned-transactions.test.ts
+++ b/backend/src/scripts/check-orphaned-transactions.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DataSource } from "typeorm";
+import {
+  checkOrphanedTransactions,
+  maskWalletAddress,
+  sanitizeErrorMessage,
+  LEDGER_BLOCKS_MISSING_WARNING,
+} from "./check-orphaned-transactions.js";
+import { TransactionRecord } from "../entities/Transaction.js";
+import { LedgerBlock } from "../entities/LedgerBlock.js";
+import { User } from "../entities/User.js";
+
+// This is a mocked-repository unit test, not a live-DB integration test.
+// Rationale: checkOrphanedTransactions() only ever calls repo.find(), so a
+// plain object with a mocked `find` per entity fully exercises the real
+// query/detection logic without needing a live Postgres connection on every
+// CI run (see backend/src/services/database.test.ts for the same style of
+// DataSource-internals mocking used elsewhere in this codebase). The repo has
+// no sqlite/in-memory TypeORM driver installed, and a real Postgres
+// connection is only available in CI via `DATABASE_URL` + `CI=true`
+// (see health.ready.integration.test.ts) — this test intentionally avoids
+// that dependency so it always runs.
+
+const RECIPIENT_A = "GA111111111111111111111111111111111111111111111111AAAA";
+const RECIPIENT_B = "GB222222222222222222222222222222222222222222222222BBBB";
+const RECIPIENT_C = "GC333333333333333333333333333333333333333333333333CCCC";
+
+function makeTransaction(overrides: Partial<TransactionRecord>): TransactionRecord {
+  return {
+    id: "tx-id-1",
+    roundId: "round-1",
+    recipient: RECIPIENT_A,
+    amount: "1000",
+    token: "native",
+    timestamp: 1732012800,
+    txHash: "hash-1",
+    status: "completed",
+    ...overrides,
+  } as TransactionRecord;
+}
+
+function makeLedgerBlock(overrides: Partial<LedgerBlock>): LedgerBlock {
+  return {
+    id: "block-id-1",
+    ledgerSeq: 100,
+    txHash: "hash-1",
+    type: "settlement",
+    projectId: "project-1",
+    recipient: RECIPIENT_A,
+    amount: "1000",
+    ledgerClosedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  } as LedgerBlock;
+}
+
+interface MockRepos {
+  dataSource: DataSource;
+  transactionFind: ReturnType<typeof vi.fn>;
+  ledgerBlockFind: ReturnType<typeof vi.fn>;
+  userFind: ReturnType<typeof vi.fn>;
+}
+
+function buildMockDataSource(options: {
+  transactions?: TransactionRecord[];
+  ledgerBlocks?: LedgerBlock[] | (() => Promise<LedgerBlock[]>);
+  users?: Array<{ walletAddress: string }>;
+}): MockRepos {
+  const transactionFind = vi.fn().mockResolvedValue(options.transactions ?? []);
+  const ledgerBlockFind =
+    typeof options.ledgerBlocks === "function"
+      ? vi.fn().mockImplementation(options.ledgerBlocks)
+      : vi.fn().mockResolvedValue(options.ledgerBlocks ?? []);
+  const userFind = vi.fn().mockImplementation(async (query: { where?: { walletAddress?: { value?: string[] } } }) => {
+    const allUsers = options.users ?? [];
+    // typeorm's In() operator wraps values in a FindOperator whose `.value`
+    // getter returns the underlying array — use it directly.
+    const requested: string[] | undefined = query?.where?.walletAddress?.value;
+    if (!requested) return allUsers;
+    return allUsers.filter((u) => requested.includes(u.walletAddress));
+  });
+
+  const dataSource = {
+    getRepository: vi.fn().mockImplementation((entity: unknown) => {
+      if (entity === TransactionRecord) return { find: transactionFind };
+      if (entity === LedgerBlock) return { find: ledgerBlockFind };
+      if (entity === User) return { find: userFind };
+      throw new Error("Unexpected entity requested from mock DataSource");
+    }),
+  } as unknown as DataSource;
+
+  return { dataSource, transactionFind, ledgerBlockFind, userFind };
+}
+
+describe("maskWalletAddress", () => {
+  it("shows first 6 and last 4 characters, masking the middle", () => {
+    expect(maskWalletAddress(RECIPIENT_A)).toBe("GA1111...AAAA");
+  });
+
+  it("returns short/empty input unchanged rather than over-masking", () => {
+    expect(maskWalletAddress("")).toBe("(none)");
+    expect(maskWalletAddress("short")).toBe("short");
+  });
+});
+
+describe("sanitizeErrorMessage", () => {
+  it("redacts credential-bearing connection strings", () => {
+    const message = 'connect ECONNREFUSED to postgresql://user:secret@localhost:5432/splitnaira';
+    expect(sanitizeErrorMessage(message)).toBe(
+      "connect ECONNREFUSED to [CONNECTION_STRING_REDACTED]"
+    );
+    expect(sanitizeErrorMessage(message)).not.toContain("secret");
+  });
+
+  it("leaves ordinary error messages untouched", () => {
+    expect(sanitizeErrorMessage("relation \"ledger_blocks\" does not exist")).toBe(
+      "relation \"ledger_blocks\" does not exist"
+    );
+  });
+});
+
+describe("checkOrphanedTransactions", () => {
+  it("does not flag a completed transaction that has a matching ledger_blocks row", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [makeTransaction({ txHash: "hash-1", status: "completed" })],
+      ledgerBlocks: [makeLedgerBlock({ txHash: "hash-1", type: "settlement" })],
+      users: [{ walletAddress: RECIPIENT_A }],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.ledgerBlocksTableAvailable).toBe(true);
+    expect(report.completedTransactionsMissingLedgerBlock).toHaveLength(0);
+    expect(report.settlementLedgerBlocksMissingTransaction).toHaveLength(0);
+  });
+
+  it("flags a completed transaction with NO matching ledger_blocks row", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [
+        makeTransaction({ id: "tx-orphan", txHash: "hash-missing", status: "completed", recipient: RECIPIENT_B }),
+      ],
+      // An unrelated milestone block (not settlement) so this fixture only
+      // exercises condition 1, not the reverse condition 2 as well.
+      ledgerBlocks: [makeLedgerBlock({ txHash: "hash-other", type: "milestone" })],
+      users: [],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.completedTransactionsMissingLedgerBlock).toHaveLength(1);
+    expect(report.completedTransactionsMissingLedgerBlock[0]).toMatchObject({
+      id: "tx-orphan",
+      txHash: "hash-missing",
+      recipientMasked: maskWalletAddress(RECIPIENT_B),
+    });
+    expect(report.settlementLedgerBlocksMissingTransaction).toHaveLength(0);
+  });
+
+  it("does not flag pending/failed transactions missing a ledger_blocks row", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [
+        makeTransaction({ id: "tx-pending", txHash: "hash-pending", status: "pending" }),
+        makeTransaction({ id: "tx-failed", txHash: "hash-failed", status: "failed" }),
+      ],
+      ledgerBlocks: [],
+      users: [],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.completedTransactionsMissingLedgerBlock).toHaveLength(0);
+  });
+
+  it("flags a settlement ledger_blocks row with no matching transactions row", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [makeTransaction({ txHash: "hash-known", status: "completed" })],
+      ledgerBlocks: [
+        makeLedgerBlock({ id: "block-orphan", txHash: "hash-unmatched", type: "settlement", recipient: RECIPIENT_C }),
+      ],
+      users: [],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.settlementLedgerBlocksMissingTransaction).toHaveLength(1);
+    expect(report.settlementLedgerBlocksMissingTransaction[0]).toMatchObject({
+      id: "block-orphan",
+      txHash: "hash-unmatched",
+      recipientMasked: maskWalletAddress(RECIPIENT_C),
+    });
+  });
+
+  it("does not flag a milestone-type ledger_blocks row missing a transaction (only settlement type counts)", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [],
+      ledgerBlocks: [makeLedgerBlock({ txHash: "hash-milestone", type: "milestone" })],
+      users: [],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.settlementLedgerBlocksMissingTransaction).toHaveLength(0);
+  });
+
+  it("reports ledgerBlocksTableAvailable=false and adds a warning instead of crashing when ledger_blocks doesn't exist", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [makeTransaction({ txHash: "hash-1", status: "completed" })],
+      ledgerBlocks: async () => {
+        const error = new Error('relation "ledger_blocks" does not exist') as Error & { code: string };
+        error.code = "42P01";
+        throw error;
+      },
+      users: [],
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.ledgerBlocksTableAvailable).toBe(false);
+    expect(report.warnings).toContain(LEDGER_BLOCKS_MISSING_WARNING);
+    // With the table unavailable, neither hard-orphan list should be
+    // populated (no false positives from a missing cross-check source).
+    expect(report.completedTransactionsMissingLedgerBlock).toHaveLength(0);
+    expect(report.settlementLedgerBlocksMissingTransaction).toHaveLength(0);
+  });
+
+  it("re-throws unexpected (non-42P01) ledger_blocks query errors", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [],
+      ledgerBlocks: async () => {
+        throw new Error("connection terminated unexpectedly");
+      },
+      users: [],
+    });
+
+    await expect(checkOrphanedTransactions(dataSource)).rejects.toThrow(
+      "connection terminated unexpectedly"
+    );
+  });
+
+  it("reports unregistered recipients as an informational, masked count/sample (not a hard orphan)", async () => {
+    const { dataSource } = buildMockDataSource({
+      transactions: [
+        makeTransaction({ id: "tx-1", txHash: "hash-1", recipient: RECIPIENT_A, status: "completed" }),
+        makeTransaction({ id: "tx-2", txHash: "hash-2", recipient: RECIPIENT_B, status: "completed" }),
+      ],
+      ledgerBlocks: [
+        makeLedgerBlock({ txHash: "hash-1", recipient: RECIPIENT_A, type: "settlement" }),
+        makeLedgerBlock({ id: "block-2", txHash: "hash-2", recipient: RECIPIENT_B, type: "settlement" }),
+      ],
+      users: [{ walletAddress: RECIPIENT_A }], // RECIPIENT_B is not a registered user
+    });
+
+    const report = await checkOrphanedTransactions(dataSource);
+
+    expect(report.unregisteredRecipients.count).toBe(1);
+    expect(report.unregisteredRecipients.sampleMasked).toEqual([maskWalletAddress(RECIPIENT_B)]);
+    // Sample must never contain the full, unmasked wallet address.
+    expect(report.unregisteredRecipients.sampleMasked[0]).not.toBe(RECIPIENT_B);
+    // A registered recipient's transaction is still fully reconciled.
+    expect(report.completedTransactionsMissingLedgerBlock).toHaveLength(0);
+  });
+});

--- a/backend/src/scripts/check-orphaned-transactions.ts
+++ b/backend/src/scripts/check-orphaned-transactions.ts
@@ -1,0 +1,306 @@
+/**
+ * Data integrity check for orphaned transaction records (#937).
+ *
+ * `transactions` (TransactionRecord) has no real foreign keys: `roundId` and
+ * `recipient` are plain varchars pointing at on-chain Soroban state, not at
+ * any local table (there are zero `@ManyToOne`/`@JoinColumn` relations
+ * anywhere in `src/entities`). So the classic "dangling FK" definition of
+ * "orphaned" does not apply here.
+ *
+ * What *can* legitimately drift is reconciliation between the two places a
+ * completed distribution might be recorded:
+ *   - `transactions`, written by this app when it observes a payout, and
+ *   - `ledger_blocks`, which this repo only ever *reads* from
+ *     (`services/ledger.service.ts`, `routes/ledger.ts`) and never writes to,
+ *     and which — notably — has NO migration creating it at all (see
+ *     `src/migrations/`). On a freshly migrated database the table will not
+ *     exist; this script treats that as a first-class, clearly reported
+ *     condition rather than a crash.
+ *
+ * Detected conditions:
+ *   1. A `completed` transaction with no matching `ledger_blocks` row
+ *      (by `txHash`) — the app believes a payout settled but there is no
+ *      independent on-chain settlement record on file.
+ *   2. A `settlement`-type `ledger_blocks` row with no matching
+ *      `transactions` row (by `txHash`) — the reverse drift signal.
+ *   3. (Informational only, not a hard orphan) recipient wallet addresses
+ *      referenced by `transactions`/`ledger_blocks` with no matching
+ *      `users.walletAddress` row. Recipients are wallet addresses and are
+ *      NOT required to be registered users anywhere in this codebase
+ *      (`routes/transactions.ts` never checks `users` before accepting or
+ *      returning a transaction), so this is reported as a count/sample only.
+ *
+ * Run standalone:
+ *   cd backend && npx tsx src/scripts/check-orphaned-transactions.ts
+ *
+ * Exit code is 1 if either hard condition (1 or 2) has findings, 0 otherwise.
+ * See docs/orphaned-transaction-remediation.md for what to do with the
+ * output.
+ */
+import "reflect-metadata";
+import { fileURLToPath } from "url";
+import { In, type DataSource } from "typeorm";
+import { TransactionRecord } from "../entities/Transaction.js";
+import { LedgerBlock } from "../entities/LedgerBlock.js";
+import { User } from "../entities/User.js";
+import { initDatabase, closeDatabase } from "../services/database.js";
+import { logger } from "../services/logger.js";
+
+/** Postgres error code for "relation does not exist" (undefined_table). */
+const UNDEFINED_TABLE_ERROR_CODE = "42P01";
+
+export const LEDGER_BLOCKS_MISSING_WARNING =
+  "The ledger_blocks table does not exist in this database (no migration in " +
+  "src/migrations currently creates it). Cross-checks between transactions " +
+  "and ledger_blocks were skipped for this run.";
+
+/**
+ * Masks a wallet address for safe display: first 6 + last 4 characters,
+ * mirroring the truncation convention already used in
+ * frontend/src/components/projects/ProjectsList.tsx.
+ */
+export function maskWalletAddress(address: string): string {
+  if (!address) return "(none)";
+  if (address.length <= 10) return address;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export interface CompletedTransactionMissingLedgerBlock {
+  id: string;
+  roundId: string;
+  txHash: string;
+  recipientMasked: string;
+  timestamp: number;
+}
+
+export interface SettlementLedgerBlockMissingTransaction {
+  id: string;
+  ledgerSeq: number;
+  txHash: string;
+  projectId?: string;
+  recipientMasked?: string;
+  ledgerClosedAt: Date;
+}
+
+export interface UnregisteredRecipientsSummary {
+  count: number;
+  sampleMasked: string[];
+}
+
+export interface OrphanedTransactionsReport {
+  /** Whether the ledger_blocks table could be queried at all. */
+  ledgerBlocksTableAvailable: boolean;
+  completedTransactionsMissingLedgerBlock: CompletedTransactionMissingLedgerBlock[];
+  settlementLedgerBlocksMissingTransaction: SettlementLedgerBlockMissingTransaction[];
+  /** Informational only — recipients need not be registered users. */
+  unregisteredRecipients: UnregisteredRecipientsSummary;
+  warnings: string[];
+}
+
+function isUndefinedTableError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === UNDEFINED_TABLE_ERROR_CODE
+  );
+}
+
+const WALLET_LOOKUP_CHUNK_SIZE = 1000;
+
+async function findExistingWalletAddresses(
+  userRepo: ReturnType<DataSource["getRepository"]>,
+  addresses: string[]
+): Promise<Set<string>> {
+  const found = new Set<string>();
+  for (let i = 0; i < addresses.length; i += WALLET_LOOKUP_CHUNK_SIZE) {
+    const chunk = addresses.slice(i, i + WALLET_LOOKUP_CHUNK_SIZE);
+    if (chunk.length === 0) continue;
+    const rows = await userRepo.find({ where: { walletAddress: In(chunk) } });
+    for (const row of rows as Array<{ walletAddress: string }>) {
+      found.add(row.walletAddress);
+    }
+  }
+  return found;
+}
+
+/**
+ * Core detection logic, extracted so it can be exercised directly in tests
+ * against a mocked DataSource/repository set (see the co-located test file)
+ * without requiring a live Postgres connection.
+ *
+ * Note on scale: this loads the full `transactions` and `ledger_blocks`
+ * tables into memory to diff by txHash in JS. That's fine for an
+ * occasional/cron-style integrity check at this project's current data
+ * volume; if either table grows very large, consider windowing this by a
+ * timestamp/ledgerSeq range instead of scanning the whole table.
+ */
+export async function checkOrphanedTransactions(
+  dataSource: DataSource
+): Promise<OrphanedTransactionsReport> {
+  const warnings: string[] = [];
+  const transactionRepo = dataSource.getRepository(TransactionRecord);
+  const ledgerBlockRepo = dataSource.getRepository(LedgerBlock);
+  const userRepo = dataSource.getRepository(User);
+
+  const transactions = await transactionRepo.find();
+
+  let ledgerBlocksTableAvailable = true;
+  let ledgerBlocks: LedgerBlock[] = [];
+  try {
+    ledgerBlocks = await ledgerBlockRepo.find();
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      ledgerBlocksTableAvailable = false;
+      warnings.push(LEDGER_BLOCKS_MISSING_WARNING);
+    } else {
+      throw error;
+    }
+  }
+
+  const ledgerBlockTxHashes = new Set(ledgerBlocks.map((b) => b.txHash));
+  const transactionTxHashes = new Set(transactions.map((t) => t.txHash));
+
+  const completedTransactionsMissingLedgerBlock: CompletedTransactionMissingLedgerBlock[] =
+    ledgerBlocksTableAvailable
+      ? transactions
+          .filter((t) => t.status === "completed" && !ledgerBlockTxHashes.has(t.txHash))
+          .map((t) => ({
+            id: t.id,
+            roundId: t.roundId,
+            txHash: t.txHash,
+            recipientMasked: maskWalletAddress(t.recipient),
+            timestamp: t.timestamp,
+          }))
+      : [];
+
+  const settlementLedgerBlocksMissingTransaction: SettlementLedgerBlockMissingTransaction[] =
+    ledgerBlocksTableAvailable
+      ? ledgerBlocks
+          .filter((b) => b.type === "settlement" && !transactionTxHashes.has(b.txHash))
+          .map((b) => ({
+            id: b.id,
+            ledgerSeq: b.ledgerSeq,
+            txHash: b.txHash,
+            projectId: b.projectId,
+            recipientMasked: b.recipient ? maskWalletAddress(b.recipient) : undefined,
+            ledgerClosedAt: b.ledgerClosedAt,
+          }))
+      : [];
+
+  const distinctRecipients = Array.from(
+    new Set<string>([
+      ...transactions.map((t) => t.recipient),
+      ...ledgerBlocks.map((b) => b.recipient).filter((r): r is string => Boolean(r)),
+    ])
+  );
+
+  const existingWallets = await findExistingWalletAddresses(userRepo, distinctRecipients);
+  const unregistered = distinctRecipients.filter((r) => !existingWallets.has(r));
+
+  return {
+    ledgerBlocksTableAvailable,
+    completedTransactionsMissingLedgerBlock,
+    settlementLedgerBlocksMissingTransaction,
+    unregisteredRecipients: {
+      count: unregistered.length,
+      sampleMasked: unregistered.slice(0, 5).map(maskWalletAddress),
+    },
+    warnings,
+  };
+}
+
+/**
+ * Strips anything that looks like a credential-bearing connection string
+ * (e.g. `postgresql://user:pass@host/db`) from an error message before it is
+ * logged, so a raw connection failure can never leak DATABASE_URL contents.
+ */
+export function sanitizeErrorMessage(message: string): string {
+  return message.replace(/[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^\s]*@[^\s]*/g, "[CONNECTION_STRING_REDACTED]");
+}
+
+function printReport(report: OrphanedTransactionsReport): void {
+  logger.info("Orphaned transaction integrity check summary", {
+    ledgerBlocksTableAvailable: report.ledgerBlocksTableAvailable,
+    completedTransactionsMissingLedgerBlockCount: report.completedTransactionsMissingLedgerBlock.length,
+    settlementLedgerBlocksMissingTransactionCount: report.settlementLedgerBlocksMissingTransaction.length,
+    unregisteredRecipientsCount: report.unregisteredRecipients.count,
+  });
+
+  for (const warning of report.warnings) {
+    logger.warn(warning);
+  }
+
+  if (report.completedTransactionsMissingLedgerBlock.length > 0) {
+    logger.warn(
+      `Found ${report.completedTransactionsMissingLedgerBlock.length} completed transaction(s) with no matching ledger_blocks settlement record:`
+    );
+    for (const tx of report.completedTransactionsMissingLedgerBlock) {
+      logger.warn(
+        `  id=${tx.id} roundId=${tx.roundId} txHash=${tx.txHash} recipient=${tx.recipientMasked} timestamp=${tx.timestamp}`
+      );
+    }
+  }
+
+  if (report.settlementLedgerBlocksMissingTransaction.length > 0) {
+    logger.warn(
+      `Found ${report.settlementLedgerBlocksMissingTransaction.length} settlement ledger_blocks row(s) with no matching transactions row:`
+    );
+    for (const b of report.settlementLedgerBlocksMissingTransaction) {
+      logger.warn(
+        `  id=${b.id} ledgerSeq=${b.ledgerSeq} txHash=${b.txHash} projectId=${b.projectId ?? "-"} recipient=${b.recipientMasked ?? "-"}`
+      );
+    }
+  }
+
+  if (report.unregisteredRecipients.count > 0) {
+    logger.info(
+      `Informational: ${report.unregisteredRecipients.count} distinct recipient wallet(s) referenced in ` +
+        `transactions/ledger_blocks have no matching users row (sample: ${report.unregisteredRecipients.sampleMasked.join(", ")}). ` +
+        "This is expected — recipients are not required to be registered users in this system."
+    );
+  }
+}
+
+async function runCli(): Promise<number> {
+  let dataSource: DataSource;
+  try {
+    dataSource = await initDatabase();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("Failed to connect to the database", { error: sanitizeErrorMessage(message) });
+    return 1;
+  }
+
+  try {
+    const report = await checkOrphanedTransactions(dataSource);
+    printReport(report);
+    const hasFindings =
+      report.completedTransactionsMissingLedgerBlock.length > 0 ||
+      report.settlementLedgerBlocksMissingTransaction.length > 0;
+    return hasFindings ? 1 : 0;
+  } finally {
+    await closeDatabase();
+  }
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const isDirectRun =
+  process.argv[1] &&
+  (process.argv[1].endsWith("check-orphaned-transactions.ts") ||
+    process.argv[1].endsWith("check-orphaned-transactions.js") ||
+    process.argv[1] === __filename);
+
+if (isDirectRun) {
+  runCli()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("Unexpected error running orphaned transaction check", {
+        error: sanitizeErrorMessage(message),
+      });
+      process.exitCode = 1;
+    });
+}

--- a/docs/orphaned-transaction-remediation.md
+++ b/docs/orphaned-transaction-remediation.md
@@ -1,0 +1,250 @@
+# Orphaned Transaction Record Remediation (#937)
+
+> **Issue:** #937
+> **Area:** Backend database integrity
+> **Script:** `backend/src/scripts/check-orphaned-transactions.ts`
+
+## Purpose
+
+This document explains the backend data integrity check for orphaned transaction
+records, what each condition it reports actually means, plausible root causes,
+and how to remediate each one. It also documents why the check does not
+attempt to enforce a hard foreign-key constraint, and confirms what indexing
+is (and isn't) missing.
+
+## Why "orphaned" doesn't mean what it usually means here
+
+`transactions` (`TransactionRecord` in `backend/src/entities/Transaction.ts`)
+has no real foreign keys. `roundId` and `recipient` are plain `varchar`
+columns — `roundId` refers to on-chain Soroban project/round state, and
+`recipient` is a Stellar wallet address. Neither points at a row in another
+Postgres table, and grepping `backend/src/entities/` confirms there is no
+`@ManyToOne`/`@JoinColumn` anywhere in this codebase. So the classic "child
+row whose parent was deleted" definition of orphan does not apply to this
+schema — there is no local parent row to lose.
+
+What *can* legitimately drift is reconciliation between the two places a
+completed distribution might be recorded:
+
+- **`transactions`** — written by this app (see `PayoutHistoryService`,
+  `EventListenerService`) when it observes a payout.
+- **`ledger_blocks`** (`LedgerBlock` entity) — read-only from this
+  repo's point of view. `backend/src/services/ledger.service.ts` and
+  `backend/src/routes/ledger.ts` only ever query it; nothing in `backend/src`
+  writes to it. **Importantly, no migration in `backend/src/migrations`
+  creates the `ledger_blocks` table at all.** On a database migrated purely
+  from this repo's migration set, `ledger_blocks` will not exist. It is
+  presumably intended to be populated by an out-of-repo ingestion process
+  reading confirmed on-chain settlements — but as shipped today, in a typical
+  local/dev database, **this table simply does not exist, so the
+  transactions↔ledger_blocks cross-check will not find anything to compare
+  against.** The script detects this and reports it explicitly rather than
+  crashing or silently producing misleading results (see "Running the
+  check" below).
+
+Given that, this check redefines "orphan" pragmatically as a **cross-source
+reconciliation** between these two tables, plus one informational-only
+signal.
+
+## What the check reports
+
+Run via `check-orphaned-transactions.ts` → `checkOrphanedTransactions()`
+(the exported, independently-testable core function). Three conditions:
+
+### 1. Completed transaction with no matching `ledger_blocks` row
+
+A `transactions` row with `status = 'completed'` whose `txHash` has no
+corresponding row in `ledger_blocks`.
+
+**Meaning:** the app believes a payout settled, but there is no independent
+on-chain settlement record on file to confirm it.
+
+**Plausible root causes:**
+- The `ledger_blocks` ingestion process (external to this repo) hasn't
+  caught up yet, or has a gap in its ledger range.
+- The `ledger_blocks` table is simply unpopulated in this environment (see
+  above — true for most local/dev databases today).
+- A transaction's status was set to `completed` incorrectly (application bug,
+  or a manual DB edit) without the payout actually settling on-chain.
+
+**Remediation:**
+1. First rule out the environment-level explanation: check whether
+   `ledger_blocks` is populated at all (`SELECT count(*) FROM ledger_blocks;`).
+   If it's empty or the table doesn't exist, this condition is expected noise
+   in this environment and not an actionable signal — see "Running the
+   check" for how the script itself reports this.
+2. If `ledger_blocks` is genuinely populated elsewhere (e.g. production, if
+   the external ingestion process is running there), independently verify the
+   transaction against the real Stellar ledger before trusting either source:
+   ```bash
+   stellar tx --network <NETWORK> --id <TX_HASH>
+   # or query Horizon directly:
+   curl -s "https://horizon-testnet.stellar.org/transactions/<TX_HASH>"
+   ```
+3. If the transaction did settle on-chain: this is a ledger-ingestion gap.
+   Re-run/extend the external ingestion process's catch-up window to cover
+   the missing ledger sequence range (see `EventListenerService`'s own
+   catch-up pattern in `docs/runbooks/stuck-payouts.md` for the equivalent
+   idea applied to this repo's event listener).
+4. If the transaction did **not** settle on-chain: this is an application bug
+   or bad manual edit. Correct `transactions.status` back to `pending` or
+   `failed` as appropriate — only after on-chain verification, never based on
+   the DB state alone.
+
+### 2. Settlement `ledger_blocks` row with no matching `transactions` row
+
+A `ledger_blocks` row with `type = 'settlement'` whose `txHash` has no
+corresponding row in `transactions` (any status).
+
+**Meaning:** the reverse drift signal — an on-chain settlement was recorded
+by whatever populates `ledger_blocks`, but this app never created a
+`transactions` row for it.
+
+**Plausible root causes:**
+- `EventListenerService` (or whatever normally inserts `transactions` rows)
+  had downtime and missed the event.
+- A migration or manual data change deleted the `transactions` row.
+- The settlement was initiated by a path this backend doesn't observe (e.g.
+  submitted directly on-chain, bypassing this API).
+
+**Remediation:**
+1. Confirm the transaction hash on-chain (same `stellar`/Horizon lookup as
+   above) to be sure it's a real settlement and not bad data in
+   `ledger_blocks` itself.
+2. If confirmed and the corresponding round/recipient/amount data is known,
+   backfill the missing `transactions` row (via the same insertion path the
+   app normally uses, not a raw manual `INSERT`, so any downstream
+   side-effects — e.g. SSE `transaction:confirmed` events — stay consistent).
+3. If this happens repeatedly, treat it as an event-listener reliability
+   issue: check `GET /ops/status` for listener health/lag and extend its
+   catch-up range, per `docs/runbooks/stuck-payouts.md`.
+
+### 3. Unregistered recipients (informational only — not a hard orphan)
+
+Distinct recipient wallet addresses appearing in `transactions`/
+`ledger_blocks` with no matching `users.walletAddress` row.
+
+**This is intentionally informational, not a flagged orphan.** Verified
+against `backend/src/routes/transactions.ts` and the rest of the routes: a
+`recipient` is never required to correspond to a registered `User` — payouts
+can go to any Stellar wallet address, registered or not. A high count here is
+expected and not itself a bug; it's reported only as a count + a masked
+sample, for situational awareness (e.g. spotting a bulk anomaly like every
+recent transaction going to unregistered wallets, which might indicate a
+recipient-address bug elsewhere, independent of orphan status).
+
+## Wallet address masking
+
+All wallet addresses in this check's output are masked to first 6 + last 4
+characters (e.g. `GA1111...AAAA`), mirroring the existing truncation
+convention in `frontend/src/components/projects/ProjectsList.tsx`
+(`item.recipient?.slice(0, 8)`). Structural identifiers — `id`, `roundId`,
+`txHash`, `ledgerSeq`, `projectId` — are printed in full since they aren't
+secrets. `DATABASE_URL`/connection credentials are never printed; the script
+also sanitizes any connection-failure error message (stripping anything that
+looks like a credential-bearing `scheme://user:pass@host` string) before
+logging it, as defense-in-depth in case a future driver error ever embedded
+one.
+
+## On database constraints
+
+**No new database constraint is being added, deliberately.** A hard foreign
+key between `transactions` and `ledger_blocks` would be actively wrong here:
+the two tables are written by independently-timed subsystems (this app for
+`transactions`; a separate/external process — when it exists — for
+`ledger_blocks`), so a `transactions` row can legitimately exist before its
+`ledger_blocks` counterpart arrives, and vice versa. Enforcing an FK at
+insert time would reject perfectly valid eventual-consistency writes on
+either side.
+
+**Existing indexes were checked and nothing is missing** for this check's own
+query performance:
+- `TransactionRecord.txHash` already has a unique index
+  (`IDX_transactions_tx_hash`, from
+  `1760000000005-AddUniqueIndexTransactionHash.ts` — see the migration-bug
+  note below for a caveat on this specific migration).
+- `LedgerBlock.txHash` already has a plain index (`IDX_ledger_blocks_tx_hash`).
+
+Both join keys used by this check are already indexed. No new migration is
+proposed.
+
+## A pre-existing, unrelated migration bug found during validation
+
+While validating this check against a freshly migrated local database
+(`npm run migration:run` against a brand-new Postgres instance), migration
+`1760000000005-AddUniqueIndexTransactionHash` failed with `relation
+"IDX_transactions_tx_hash" already exists` (Postgres error `42P07`). This is
+because the *initial* migration, `1760000000000-InitialUserAndTransactionRecord`,
+already creates that exact index inline (see its `up()` method). Migration
+`1760000000005` redundantly tries to create it again.
+
+TypeORM runs a pending migration batch in a single transaction, so this
+failure rolled back **all** pending migrations, leaving a freshly migrated
+database with zero application tables (only the `migrations` bookkeeping
+table survives). In other words: **`npm run migration:run` against a
+genuinely empty database currently fails outright** for reasons unrelated to
+this issue.
+
+This is out of scope for #937 to fix (it's a pre-existing migration-history
+bug, not an orphaned-transaction concern), but is recorded here since it
+directly affects anyone trying to follow this document's "Running the check"
+steps from a truly empty database. Until it's fixed, standing up a fresh
+local database requires either applying migrations 1-4 and then marking
+migration 5 as already-applied (its effect is already present), or fixing the
+duplicate `CREATE UNIQUE INDEX` in migration 5 itself. Any environment that
+was migrated before this bug was introduced, or that already has these
+tables from an earlier migration run, is unaffected.
+
+## Running the check
+
+```bash
+cd backend
+DATABASE_URL=postgresql://user:password@localhost:5432/splitnaira \
+  HORIZON_URL=https://horizon-testnet.stellar.org \
+  SOROBAN_RPC_URL=https://soroban-testnet.stellar.org \
+  SOROBAN_NETWORK_PASSPHRASE="Test SDF Network ; September 2015" \
+  CONTRACT_ID=<your-contract-id> \
+  SIMULATOR_ACCOUNT=<your-simulator-account> \
+  npx tsx src/scripts/check-orphaned-transactions.ts
+```
+
+(Or rely on a `.env` file already populated per `backend/.env.example`, which
+covers the required env vars.)
+
+The script exits `0` if no hard-orphan conditions (1 or 2) were found, and
+`1` if either was found — suitable for wiring into a cron job or CI step that
+alerts on nonzero exit. If `ledger_blocks` doesn't exist in the target
+database, the script logs a warning explaining that the cross-check was
+skipped, rather than crashing or reporting misleading false positives.
+
+### Automated test coverage
+
+`backend/src/scripts/check-orphaned-transactions.test.ts` exercises the core
+`checkOrphanedTransactions()` function against a **mocked** `DataSource` (a
+plain object whose `getRepository()` returns objects with a mocked `find`
+method per entity), not a live Postgres connection. This mirrors the mocking
+style already used in `backend/src/services/database.test.ts` and means the
+test always runs in normal `npm run test` / CI, without depending on a
+provisioned database (unlike `health.ready.integration.test.ts`, which is
+gated behind `CI=true` + a real `DATABASE_URL`). It covers: a completed
+transaction with a matching ledger block (not flagged), a completed
+transaction with none (flagged), pending/failed transactions with none (not
+flagged), a settlement ledger block with no matching transaction (flagged), a
+milestone-type block with no matching transaction (not flagged — only
+`settlement` counts), the `ledger_blocks`-table-missing path (graceful
+warning, no false positives, non-42P01 errors still propagate), and the
+wallet-masking behavior for both hard findings and the informational
+recipient summary.
+
+This was additionally validated end-to-end against a real local Postgres
+instance (via this repo's `docker-compose.yml`) with seeded data reproducing
+both hard-orphan conditions and the missing-`ledger_blocks`-table case; see
+the PR/commit description for the captured output.
+
+## Related
+
+- [Stuck/Delayed Payouts Incident Response](./runbooks/stuck-payouts.md) —
+  event listener catch-up and on-chain verification procedures referenced
+  above.
+- [Audit Log Retention](./audit-log-retention.md) — sibling data-lifecycle
+  doc for another Postgres table in this backend.


### PR DESCRIPTION
## Summary
- The schema has no real foreign-key relationships to check as the issue's title implies — confirmed zero `@ManyToOne`/`@JoinColumn` anywhere in `backend/src/entities/`; `transactions.roundId`/`recipient` and `ledger_blocks.projectId`/`recipient` are plain varchars, and projects/rounds live on-chain, not in Postgres
- Redefined "orphaned" as a cross-source reconciliation between `transactions` (app-created) and `ledger_blocks` (on-chain-observed), joined on `txHash`: completed transactions with no matching settlement ledger block (flagged), settlement ledger blocks with no matching transaction (flagged), and recipients absent from `users.walletAddress` (informational only, since registration isn't required)
- New finding beyond the original scope: **no migration in this repo actually creates the `ledger_blocks` table** — on a database migrated purely from this repo's migrations, it doesn't exist; the check handles this gracefully (Postgres `42P01` → warning, not a false-flag storm)
- Also found a second pre-existing, unrelated migration bug: `1760000000005-AddUniqueIndexTransactionHash` duplicates an index already created inline by `1760000000000`, so `npm run migration:run` against a truly empty database fails with `42P07` and TypeORM rolls back the entire batch — documented in the remediation doc as out of scope for this PR, worked around only for local validation (no migration files touched)
- Wallet addresses masked (first 6 + last 4 chars) in all reported output, matching `ProjectsList.tsx`'s existing truncation convention; connection-error messages sanitized against `scheme://user:pass@host` leakage
- No new DB constraints added — a hard FK would reject legitimate eventual-consistency writes between independently-timed subsystems (app vs. on-chain listener); both existing indexes already cover the check's join keys, so nothing was actually missing
- New `docs/orphaned-transaction-remediation.md`: what each flagged condition means, root causes, concrete remediation steps, the constraints reasoning, and the migration bug

## Acceptance criteria
- [x] Script/test that detects orphaned transaction records (`backend/src/scripts/check-orphaned-transactions.ts`, core logic + CLI entrypoint)
- [x] Reports project/user/transaction identifiers safely (masked wallet addresses, sanitized connection errors)
- [x] Remediation steps documented
- [x] Database constraints considered and reasoned about explicitly (none needed)

## Test plan
- [x] `check-orphaned-transactions.test.ts` (mocked DataSource) — 12/12 passing
- [x] Real end-to-end run against a live local Postgres via this repo's `docker-compose.yml` — confirmed both flag conditions, the missing-table warning path, and masked output all work correctly with correct exit codes
- [x] `npx tsc --noEmit` — zero new errors
- [x] Full suite: baseline 65 failed/272 passed → with change 65 failed/284 passed (+12 new passing tests, zero regressions)
- [x] Scoped lint clean

closes #937 